### PR TITLE
Add site orchestrating playbook

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,46 @@
+---
+- hosts: all
+  become: yes
+  any_errors_fatal: true
+  roles:
+    - role: prepare_system
+
+- hosts: gpu
+  become: yes
+  any_errors_fatal: true
+  roles:
+    - role: install_gpu
+      when: groups['gpu'] is defined and groups['gpu'] | length > 0
+
+- hosts: all
+  become: yes
+  any_errors_fatal: true
+  roles:
+    - role: install_k8s
+
+- hosts: masters
+  become: yes
+  any_errors_fatal: true
+  run_once: true
+  roles:
+    - role: setup_registry
+
+- hosts: masters
+  become: yes
+  any_errors_fatal: true
+  roles:
+    - role: kubeadm_master
+
+- hosts: workers
+  become: yes
+  any_errors_fatal: true
+  roles:
+    - role: kubeadm_workers
+
+- hosts: masters
+  become: yes
+  any_errors_fatal: true
+  run_once: true
+  roles:
+    - role: post_install_checks
+


### PR DESCRIPTION
## Summary
- add Ansible playbook `site.yml` to orchestrate offline Kubernetes cluster setup

## Testing
- `ansible-playbook -i inventory --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_68766a0d362c832bb3511564d7e1e5fd