### PR TITLE
Add handlers to prepare_system role

### DIFF
--- a/roles/prepare_system/handlers/main.yml
+++ b/roles/prepare_system/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+# Handler to apply sysctl settings if not already loaded
+- name: Apply sysctl
+  ansible.builtin.command: sysctl --system
+  become: yes
+
+# Handler to reboot the node if required by previous tasks
+- name: Reboot if needed
+  ansible.builtin.reboot:
+    reboot_timeout: 300
+  become: yes
+


### PR DESCRIPTION
## Summary
- add handler for applying sysctl parameters
- add handler for rebooting the host when required

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68766bb525c4832bab25ce07c8246e9a