### PR TITLE
Add containerd restart handler

### DIFF
--- a/roles/install_k8s/handlers/main.yml
+++ b/roles/install_k8s/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart containerd
+  service:
+    name: containerd
+    state: restarted

--- a/roles/install_k8s/tasks/main.yml
+++ b/roles/install_k8s/tasks/main.yml
@@ -83,12 +83,13 @@
     dest: /etc/containerd/config.toml
     mode: '0644'
   become: yes
+  notify: Restart containerd
 
-- name: Enable and restart containerd
+- name: Enable and start containerd
   systemd:
     name: containerd
     enabled: yes
-    state: restarted
+    state: started
   become: yes
 
 - name: Enable kubelet service


### PR DESCRIPTION
## Summary
- add Restart containerd handler using service module
- reload containerd when the config template changes
- start containerd without forcing a restart each run

## Testing
- `ansible-playbook site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_68766e86c208832ba62452cce773bef1