### PR TITLE
Add defaults for install_k8s role

### DIFF
--- a/roles/install_k8s/defaults/main.yml
+++ b/roles/install_k8s/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# Default variables for the install_k8s role
+
+# List of Kubernetes package files to install. Kept empty by default so the
+# role does nothing if packages are not specified.
+kubernetes_packages: []
+
+# Location of the containerd configuration file deployed by this role
+containerd_config_path: "/etc/containerd/config.toml"
+
+# Placeholder variable for any future defaults specific to this role
+install_k8s_placeholder: true


### PR DESCRIPTION
## Summary
- add defaults file for install_k8s role to define optional variables

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_687673c04304832bad312294652c8fc2