### PR TITLE
Add defaults for kubeadm workers role

### DIFF
--- a/roles/kubeadm_workers/defaults/main.yml
+++ b/roles/kubeadm_workers/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Default variables for the kubeadm_workers role
+
+# Path to the container runtime socket. This is used when executing
+# the kubeadm join command. Adjust if your runtime uses a different path.
+cri_socket: "/run/containerd/containerd.sock"
+
+# Placeholder variable for any future defaults or join command tweaks
+kubeadm_workers_placeholder: true

--- a/roles/kubeadm_workers/tasks/main.yml
+++ b/roles/kubeadm_workers/tasks/main.yml
@@ -15,7 +15,7 @@
   become: yes
 
 - name: Join node to cluster
-  shell: "{{ master_join_cmd.stdout }} --cri-socket unix:///run/containerd/containerd.sock"
+  shell: "{{ master_join_cmd.stdout }} --cri-socket unix://{{ cri_socket }}"
   register: join_result
   when: not kubelet_conf.stat.exists
   become: yes


### PR DESCRIPTION
## Summary
- create defaults for kubeadm_workers
- reference cri_socket variable in join command

## Testing
- `ansible-lint | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687696f4f168832ba7a9ddcb63234906