### PR TITLE
Add registry hosts mapping option

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -40,3 +40,7 @@ registry_port: 5000
 nvidia_driver_runfile: "NVIDIA-Linux-x86_64-535.129.03.run"
 nvidia_toolkit_version: "1.15.0"        # Container toolkit package
 device_plugin_version: "v0.15.0"        # NVIDIA device plugin image tag
+
+# Hosts file configuration
+add_registry_host_entry: true            # Whether to map registry_host in /etc/hosts
+registry_master_ip: ""                  # Override master IP for registry host if needed

--- a/roles/prepare_system/defaults/main.yml
+++ b/roles/prepare_system/defaults/main.yml
@@ -3,5 +3,10 @@
 swap_fstab_path: "/etc/fstab"          # Path to the fstab file for swap configuration
 allow_reboot: false                     # Whether this role may reboot the host automatically
 
+# Whether to add the registry host entry to /etc/hosts
+add_registry_host_entry: false
+# IP address to map to registry_host; empty uses first master IP
+registry_master_ip: ""
+
 # Placeholder variable - this role currently has no critical defaults
 prepare_system_placeholder: true

--- a/roles/prepare_system/tasks/main.yml
+++ b/roles/prepare_system/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# Prepare system settings prior to Kubernetes installation
+
+- name: Determine master node IP for registry mapping
+  set_fact:
+    registry_master_ip_resolved: >-
+      {{ registry_master_ip | default(hostvars[groups['masters'][0]].ansible_host | default(hostvars[groups['masters'][0]].ansible_default_ipv4.address)) }}
+  when: add_registry_host_entry
+
+- name: Ensure {{ registry_host }} is resolvable via /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    regexp: '\s{{ registry_host }}$'
+    line: "{{ registry_master_ip_resolved }} {{ registry_host }}"
+    state: present
+  when: add_registry_host_entry
+  become: yes


### PR DESCRIPTION
## Summary
- add variables for mapping the local registry to /etc/hosts
- implement registry host update logic in `prepare_system`
- remove unused `.gitkeep`

## Testing
- `ansible-playbook -i inventory --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_68776050abf0832bbb39174ed2195172