### PR TITLE
Serve offline assets via HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,13 @@ Utility scripts for preparing an offline Kubernetes deployment.
 Use `scripts/fetch_offline_assets.sh` on a machine with internet access to
 retrieve required packages, images and manifests. Copy the resulting
 `offline_pkg_dir` and `offline_image_dir` directories to your air-gapped
-environment before running the Ansible playbook.
+environment. On the master node, start the lightweight HTTP service
+with `scripts/serve_assets.py` to expose these directories to the other
+hosts:
+
+```bash
+python3 scripts/serve_assets.py -d /opt/offline -p 8080
+```
+
+Once the service is running, execute the Ansible playbook. All nodes
+will pull packages and images from this local HTTP server.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -36,10 +36,18 @@ calico_image_version: "v3.27.2"    # Container image tag
 registry_host: "registry.local"
 registry_port: 5000
 
+# Simple HTTP server settings used to distribute offline assets
+asset_server_port: 8080
+asset_server_host: "{{ registry_host }}"
+
 # NVIDIA GPU configuration
 nvidia_driver_runfile: "NVIDIA-Linux-x86_64-535.129.03.run"
 nvidia_toolkit_version: "1.15.0"        # Container toolkit package
 device_plugin_version: "v0.15.0"        # NVIDIA device plugin image tag
+
+# List of NVIDIA container toolkit package filenames served by the asset server
+nvidia_packages:
+  - "nvidia-container-toolkit_{{ nvidia_toolkit_version }}-1_amd64.deb"
 
 # Hosts file configuration
 add_registry_host_entry: true            # Whether to map registry_host in /etc/hosts

--- a/roles/install_gpu/tasks/main.yml
+++ b/roles/install_gpu/tasks/main.yml
@@ -38,11 +38,12 @@
   changed_when: false
   become: yes
 
-- name: Copy NVIDIA driver installer
-  copy:
-    src: "{{ offline_pkg_dir }}/{{ nvidia_driver_runfile }}"
+- name: Download NVIDIA driver installer from asset server
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/pkgs/{{ nvidia_driver_runfile }}"
     dest: "/tmp/{{ nvidia_driver_runfile }}"
     mode: '0755'
+    timeout: 30
   when: nvidia_smi.rc != 0
   become: yes
 
@@ -54,12 +55,13 @@
   become: yes
 
 # Copy and install NVIDIA container toolkit packages offline
-- name: Copy NVIDIA container toolkit packages
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/nvidia_debs/
+- name: Download NVIDIA container toolkit packages from asset server
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/pkgs/{{ item }}"
+    dest: "/tmp/nvidia_debs/{{ item }}"
     mode: '0644'
-  loop: "{{ lookup('fileglob', offline_pkg_dir + '/nvidia*.deb', wantlist=True) }}"
+    timeout: 30
+  loop: "{{ nvidia_packages }}"
   become: yes
 
 - name: Install NVIDIA container toolkit packages

--- a/roles/install_k8s/tasks/main.yml
+++ b/roles/install_k8s/tasks/main.yml
@@ -7,12 +7,13 @@
     mode: '0755'
   become: yes
 
-# Copy required Kubernetes .deb packages from the control node
-- name: Copy Kubernetes packages to node
-  copy:
-    src: "{{ offline_pkg_dir }}/{{ item }}"
+# Download required Kubernetes .deb packages from the master HTTP service
+- name: Download Kubernetes packages from asset server
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/pkgs/{{ item }}"
     dest: "/tmp/k8s_debs/{{ item }}"
     mode: '0644'
+    timeout: 30
   loop: "{{ kubernetes_packages }}"
   become: yes
 
@@ -22,11 +23,12 @@
     containerd_pkg_file: "containerd.io_{{ containerd_version }}-1_amd64.deb"
   become: yes
 
-- name: Copy containerd package to node
-  copy:
-    src: "{{ offline_pkg_dir }}/{{ containerd_pkg_file }}"
+- name: Download containerd package from asset server
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/pkgs/{{ containerd_pkg_file }}"
     dest: "/tmp/k8s_debs/{{ containerd_pkg_file }}"
     mode: '0644'
+    timeout: 30
   when: containerd_pkg_file is defined
   become: yes
 

--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -59,11 +59,12 @@
   when: not pki_dir.stat.exists
   become: true
 
-- name: Copy Calico manifest
-  copy:
-    src: "{{ offline_image_dir }}/calico.yaml"
+- name: Download Calico manifest from asset server
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/images/calico.yaml"
     dest: /tmp/calico.yaml
     mode: '0644'
+    timeout: 30
   become: true
 
 - name: Apply Calico manifest

--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -8,12 +8,13 @@
     mode: '0755'
   become: yes
 
-# Copy the Docker engine .deb files from the control host
-- name: Copy Docker packages to node
-  copy:
-    src: "{{ offline_pkg_dir }}/{{ item }}"
+# Download the Docker engine .deb files from the master HTTP service
+- name: Download Docker packages from asset server
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/pkgs/{{ item }}"
     dest: "/tmp/docker_debs/{{ item }}"
     mode: '0644'
+    timeout: 30
   loop: "{{ registry_docker_packages }}"
   become: yes
 
@@ -49,11 +50,12 @@
     registry_image_tar: "registry_2.8.2.tar"
 
 # Load the registry image from local tarball
-- name: Copy registry image tarball
-  copy:
-    src: "{{ offline_image_dir }}/{{ registry_image_tar }}"
+- name: Download registry image tarball from asset server
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/images/{{ registry_image_tar }}"
     dest: /tmp/registry.tar
     mode: '0644'
+    timeout: 60
   become: yes
 
 - name: Load registry image
@@ -90,10 +92,20 @@
       - "calico-kube-controllers_{{ calico_image_version }}.tar"
     nvidia_plugin_image: "nvidia-device-plugin_{{ device_plugin_version }}.tar"
 
+# Download Kubernetes core image tarballs
+- name: Download Kubernetes core images
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/images/{{ item }}"
+    dest: "/tmp/{{ item }}"
+    mode: '0644'
+    timeout: 60
+  loop: "{{ kube_core_images }}"
+  become: yes
+
 # Load Kubernetes core images and push them to the local registry
 - name: Load and push Kubernetes core images
   shell: |
-    img=$(docker load -i {{ offline_image_dir }}/{{ item }} | awk '/Loaded image:/ {print $3}')
+    img=$(docker load -i /tmp/{{ item }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
     docker tag $img {{ registry_host }}:{{ registry_port }}/$name
     docker push {{ registry_host }}:{{ registry_port }}/$name
@@ -103,10 +115,20 @@
   loop: "{{ kube_core_images }}"
   become: yes
 
+# Download Calico images
+- name: Download Calico images
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/images/{{ item }}"
+    dest: "/tmp/{{ item }}"
+    mode: '0644'
+    timeout: 60
+  loop: "{{ calico_images }}"
+  become: yes
+
 # Load Calico networking images and push to the registry
 - name: Load and push Calico images
   shell: |
-    img=$(docker load -i {{ offline_image_dir }}/{{ item }} | awk '/Loaded image:/ {print $3}')
+    img=$(docker load -i /tmp/{{ item }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
     docker tag $img {{ registry_host }}:{{ registry_port }}/$name
     docker push {{ registry_host }}:{{ registry_port }}/$name
@@ -116,10 +138,19 @@
   loop: "{{ calico_images }}"
   become: yes
 
+# Download NVIDIA device plugin image
+- name: Download NVIDIA device plugin image
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/images/{{ nvidia_plugin_image }}"
+    dest: "/tmp/{{ nvidia_plugin_image }}"
+    mode: '0644'
+    timeout: 60
+  become: yes
+
 # Load NVIDIA device plugin image and push
 - name: Load and push NVIDIA device plugin image
   shell: |
-    img=$(docker load -i {{ offline_image_dir }}/{{ nvidia_plugin_image }} | awk '/Loaded image:/ {print $3}')
+    img=$(docker load -i /tmp/{{ nvidia_plugin_image }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
     docker tag $img {{ registry_host }}:{{ registry_port }}/$name
     docker push {{ registry_host }}:{{ registry_port }}/$name

--- a/scripts/serve_assets.py
+++ b/scripts/serve_assets.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Simple HTTP server for offline assets.
+
+This script serves the directory containing downloaded package
+and image files so that other nodes in the cluster can fetch them
+without manual copying. It only uses Python's standard library and
+therefore works in air‑gapped environments.
+"""
+import http.server
+import socketserver
+import os
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Serve offline assets via HTTP")
+    parser.add_argument(
+        "-d", "--directory", default="/opt/offline",
+        help="Root directory containing 'pkgs' and 'images' subdirectories",
+    )
+    parser.add_argument(
+        "-p", "--port", type=int, default=8080, help="Port to listen on"
+    )
+    args = parser.parse_args()
+
+    os.chdir(args.directory)
+    handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer(("", args.port), handler) as httpd:
+        print(f"Serving {args.directory} on port {args.port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            httpd.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `serve_assets.py` helper to run a tiny HTTP server
- fetch packages and images from the master HTTP service instead of using `copy`
- configure asset server defaults and NVIDIA package list
- document how to start the HTTP service

## Testing
- `ansible-playbook site.yml --syntax-check`
- `python3 -m py_compile scripts/serve_assets.py`

------
https://chatgpt.com/codex/tasks/task_e_687764378738832bad8163b04be5416d