### PR TITLE
Fix fetch script for packages with no dependencies

### DIFF
--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -84,6 +84,8 @@ fetch_deb() {
   version="${version//%3a/:}"
   echo "Downloading $name=$version and dependencies"
   pushd "$download_tmp" >/dev/null
+  # Avoid literal '*.deb' when there are no dependency packages
+  shopt -s nullglob
   # Download package and dependencies into $download_tmp
   apt-get -y -o Dir::Cache::archives="$download_tmp" --download-only install "${name}=${version}"
   # Rename the primary package to match the file name expected by Ansible
@@ -104,6 +106,7 @@ fetch_deb() {
       rm -f "$dep"
     fi
   done
+  shopt -u nullglob
   popd >/dev/null
 }
 


### PR DESCRIPTION
## Summary
- handle case where apt produces no dependency packages

## Testing
- `bash -n scripts/fetch_offline_assets.sh`
- `python3 -m py_compile scripts/serve_assets.py`
- `ansible-playbook --syntax-check site.yml`


------
https://chatgpt.com/codex/tasks/task_e_68776f43228c832bbd19ecc7f5a37e14