### PR TITLE
Remove redundant kubernetes-cni download

### DIFF
--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -112,6 +112,11 @@ fetch_deb() {
 
 cd "$offline_pkg_dir"
 for pkg in "${kubernetes_packages[@]}" "${registry_packages[@]}" "$containerd_pkg_file"; do
+  # kubernetes-cni is fetched automatically as a dependency of other
+  # Kubernetes packages, so skip explicitly downloading it here
+  if [[ $pkg == kubernetes-cni_* ]]; then
+    continue
+  fi
   fetch_deb "$pkg"
 done
 


### PR DESCRIPTION
## Summary
- skip explicitly downloading kubernetes-cni in `fetch_offline_assets.sh`
  - kubernetes-cni gets downloaded automatically as a dependency

## Testing
- `shellcheck scripts/fetch_offline_assets.sh`


------
https://chatgpt.com/codex/tasks/task_e_687770686084832bb9af5f49186168ae