### PR TITLE
Parameterize registry version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ python3 scripts/serve_assets.py -d /opt/offline -p 8080
 
 Once the service is running, execute the Ansible playbook. All nodes
 will pull packages and images from this local HTTP server.
+
+The registry image version can be customized via the `registry_version`
+variable in `group_vars/all.yml`. Ensure the matching tarball is available
+under `offline_image_dir` before running the playbook.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -18,6 +18,9 @@ kubernetes_packages:
 # Container runtime
 containerd_version: "1.7.27"
 
+# Version of the registry image used for the local Docker registry
+registry_version: "2.8.2"
+
 # Docker packages for the local registry host
 registry_docker_packages:
   - docker-ce_5:28.3.2-1~debian.12~bookworm_amd64.deb

--- a/roles/setup_registry/defaults/main.yml
+++ b/roles/setup_registry/defaults/main.yml
@@ -4,6 +4,9 @@
 # Port for the local Docker registry. Override in group_vars if needed
 registry_port: "5000"
 
+# Registry image version
+registry_version: "2.8.2"
+
 # List of Kubernetes core image tar files to load into the registry.
 # These should be specified in group_vars with the exact filenames present
 # in the offline image directory.

--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -45,7 +45,7 @@
 
 - name: Set registry image tar name
   set_fact:
-    registry_image_tar: "registry_2.8.2.tar"
+    registry_image_tar: "registry_{{ registry_version }}.tar"
 
 # Load the registry image from local tarball
 - name: Download registry image tarball from asset server

--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -25,13 +25,13 @@ then
 fi
 
 read -r offline_pkg_dir offline_image_dir kube_version kube_version_pkgs \
-        containerd_version calico_version calico_image_version \
+        registry_version containerd_version calico_version calico_image_version \
         device_plugin_version <<< "$(python3 - <<PY
 import yaml,sys
 with open('$VARS_FILE') as f:
     data = yaml.safe_load(f)
 fields = ['offline_pkg_dir','offline_image_dir','kube_version',
-          'kube_version_pkgs','containerd_version','calico_version',
+          'kube_version_pkgs','registry_version','containerd_version','calico_version',
           'calico_image_version','device_plugin_version']
 print(' '.join(str(data.get(k,'')) for k in fields))
 PY
@@ -137,8 +137,8 @@ done
 cd "$offline_image_dir"
 
 # Registry image
-docker pull registry:2.8.2
-docker save registry:2.8.2 -o registry_2.8.2.tar
+docker pull registry:${registry_version}
+docker save registry:${registry_version} -o "registry_${registry_version}.tar"
 
 # Kubernetes control plane images
 if command -v kubeadm >/dev/null; then


### PR DESCRIPTION
## Summary
- make the registry image version configurable
- use `registry_version` variable in offline asset script and Ansible role
- document new variable in README

## Testing
- `shellcheck scripts/fetch_offline_assets.sh`
- `python3 -m py_compile scripts/serve_assets.py`
- `ansible-playbook -i inventory/hosts --syntax-check site.yml`


------
https://chatgpt.com/codex/tasks/task_e_68779a3d31f4832bb14309f550e82be2