### PR TITLE
Fix kubeadm preflight issues for air-gapped installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ will pull packages and images from this local HTTP server.
 The registry image version can be customized via the `registry_version`
 variable in `group_vars/all.yml`. Ensure the matching tarball is available
 under `offline_image_dir` before running the playbook.
+
+The `prepare_system` role configures kernel parameters required for Kubernetes.
+It disables swap, loads the `overlay` and `br_netfilter` modules, and enables
+IPv4 forwarding via `/etc/sysctl.d/k8s.conf`. These settings ensure that
+`kubeadm` passes preflight checks in fully air‑gapped deployments.

--- a/roles/prepare_system/tasks/main.yml
+++ b/roles/prepare_system/tasks/main.yml
@@ -16,6 +16,48 @@
   when: add_registry_host_entry
   become: yes
 
+- name: Disable swap at runtime
+  command: swapoff -a
+  when: ansible_swaptotal_mb > 0
+  become: yes
+
+- name: Ensure swap is disabled in fstab
+  replace:
+    path: "{{ swap_fstab_path }}"
+    regexp: '^([^#].*\sswap\s.*)$'
+    replace: '# \1'
+    backup: yes
+  become: yes
+
+- name: Load Kubernetes kernel modules
+  modprobe:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - overlay
+    - br_netfilter
+  become: yes
+
+- name: Persist kernel modules
+  copy:
+    dest: /etc/modules-load.d/k8s.conf
+    content: |
+      overlay
+      br_netfilter
+    mode: '0644'
+  become: yes
+
+- name: Configure sysctl for Kubernetes networking
+  copy:
+    dest: /etc/sysctl.d/k8s.conf
+    content: |
+      net.bridge.bridge-nf-call-ip6tables = 1
+      net.bridge.bridge-nf-call-iptables = 1
+      net.ipv4.ip_forward = 1
+    mode: '0644'
+  notify: Apply sysctl
+  become: yes
+
 - name: Ensure /etc/docker directory exists
   file:
     path: /etc/docker


### PR DESCRIPTION
## Summary
- set kernel modules, ip forwarding and swap settings in `prepare_system`
- document the automatic configuration in README

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6877bbbeabb0832b9eab1e5520eeeefb