### PR TITLE
Fix worker join script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ python3 scripts/serve_assets.py -d /opt/offline -p 8080
 Once the service is running, execute the Ansible playbook. All nodes
 will pull packages and images from this local HTTP server.
 
+During initialization the master node writes the `kubeadm` join command to
+`/tmp/join.sh`. Worker nodes read this file to join the cluster without needing
+direct communication with the internet.
+
 The registry image version can be customized via the `registry_version`
 variable in `group_vars/all.yml`. Ensure the matching tarball is available
 under `offline_image_dir` before running the playbook.

--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -31,6 +31,13 @@
     join_command: "{{ join_command_result.stdout }}"
   become: true
 
+- name: Write join command script for workers
+  copy:
+    content: "{{ join_command }}\n"
+    dest: /tmp/join.sh
+    mode: '0755'
+  become: true
+
 - name: Ensure .kube directory exists for root
   file:
     path: /root/.kube


### PR DESCRIPTION
## Summary
- write kubeadm join command to `/tmp/join.sh`
- document generated script in README

## Testing
- `ansible-playbook --syntax-check site.yml`


------
https://chatgpt.com/codex/tasks/task_e_6877c0c5326c832b9418ace67e3942bc