### PR TITLE
Patch Calico manifest with eBPF

### DIFF
--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -187,6 +187,23 @@ curl -L \
   -o calico.yaml \
   "https://raw.githubusercontent.com/projectcalico/calico/${calico_version}/manifests/calico.yaml"
 
+# Enable eBPF mode and host networking by default
+cat <<'EOF' >> calico.yaml
+
+---
+apiVersion: projectcalico.org/v3
+kind: FelixConfiguration
+metadata:
+  name: default
+spec:
+  bpfEnabled: true
+EOF
+
+# Ensure networking environment variables match our defaults
+sed -i '/name: CLUSTER_TYPE/{n;s/.*/              value: "k8s,bgp"/}' calico.yaml
+sed -i '/name: CALICO_IPV4POOL_IPIP/{n;s/.*/              value: "Never"/}' calico.yaml
+sed -i '/name: CALICO_IPV4POOL_VXLAN/{n;s/.*/              value: "Never"/}' calico.yaml
+
 # Cleanup temporary download directory
 rm -rf "$download_tmp"
 


### PR DESCRIPTION
## Summary
- modify `fetch_offline_assets.sh` to enable eBPF in the Calico manifest
- enforce Calico env vars for host networking
- set `CALICO_IPV4POOL_IPIP` to `Never` so no overlay is recreated

## Testing
- `shellcheck scripts/fetch_offline_assets.sh`


------
https://chatgpt.com/codex/tasks/task_e_6878bf8d3eec832b9179ed0176eac2e9