### PR TITLE
Fix Calico manifest apply for air‑gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ The `prepare_system` role configures kernel parameters required for Kubernetes.
 It disables swap, loads the `overlay` and `br_netfilter` modules, and enables
 IPv4 forwarding via `/etc/sysctl.d/k8s.conf`. These settings ensure that
 `kubeadm` passes preflight checks in fully air‑gapped deployments.
+
+Calico's manifest is applied in two phases. The playbook first installs its
+CustomResourceDefinitions and waits until the `FelixConfiguration` CRD becomes
+available before applying the rest of the resources. This avoids failures that
+can occur when the API server has not yet processed the CRDs during the initial
+apply.

--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -74,6 +74,22 @@
     timeout: 30
   become: true
 
+- name: Apply Calico CRDs (initial pass)
+  shell: kubectl apply -f /tmp/calico.yaml || true
+  environment: "{{ kubectl_env }}"
+  become: true
+  failed_when: false
+
+- name: Wait for FelixConfiguration CRD
+  shell: kubectl get crd felixconfigurations.crd.projectcalico.org
+  register: crd_result
+  retries: 10
+  delay: 5
+  until: crd_result.rc == 0
+  environment: "{{ kubectl_env }}"
+  changed_when: false
+  become: true
+
 - name: Apply Calico manifest
   shell: kubectl apply -f /tmp/calico.yaml
   environment: "{{ kubectl_env }}"


### PR DESCRIPTION
## Summary
- apply Calico manifest in two stages so CRDs load before FelixConfiguration
- document the Calico CRD step in README

## Testing
- `apt-get update`
- `apt-get install -y ansible`
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6878c56257f0832baaccec9044e7e79e