### PR TITLE
Fix Calico apiVersion

### DIFF
--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -191,7 +191,7 @@ curl -L \
 cat <<'EOF' >> calico.yaml
 
 ---
-apiVersion: projectcalico.org/v3
+apiVersion: crd.projectcalico.org/v1
 kind: FelixConfiguration
 metadata:
   name: default


### PR DESCRIPTION
## Summary
- fix Calico manifest apiVersion in fetch script

## Testing
- `bash -n scripts/fetch_offline_assets.sh`
- `shellcheck scripts/fetch_offline_assets.sh`

------
https://chatgpt.com/codex/tasks/task_e_6878cb2e8d08832b89f520e35bcb1927