### PR TITLE
Fix Calico patch resource

### DIFF
--- a/roles/post_install_checks/tasks/main.yml
+++ b/roles/post_install_checks/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Enable Calico eBPF
   shell: |
-    kubectl patch felixconfiguration.p default --type merge -p '{"spec": {"bpfEnabled": true, "bpfKubeProxyIptablesCleanupEnabled": false}}'
+    kubectl patch felixconfigurations default --type merge -p '{"spec": {"bpfEnabled": true, "bpfKubeProxyIptablesCleanupEnabled": false}}'
   environment: "{{ kubectl_env }}"
   become: true
 


### PR DESCRIPTION
## Summary
- correct the resource name used when enabling Calico eBPF

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878d5f58230832ba7ab790501817e25