### PR TITLE
Add Traefik Gateway role manifests

### DIFF
--- a/roles/traefik_gateway/files/gateway.yaml
+++ b/roles/traefik_gateway/files/gateway.yaml
@@ -2,24 +2,19 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: traefik-gateway
-  namespace: traefik
+  namespace: default
 spec:
-  gatewayClassName: traefik-gw-class
+  gatewayClassName: traefik
   listeners:
-  - name: http
-    protocol: HTTP
-    port: 80
-    allowedRoutes:
-      namespaces:
-        from: All
-  - name: https
-    protocol: HTTPS
-    port: 443
-    tls:
-      mode: Terminate
-      certificateRefs:
-        - kind: Secret
-          name: traefik-cert
-    allowedRoutes:
-      namespaces:
-        from: All
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      protocol: HTTPS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/roles/traefik_gateway/files/gatewayclass.yaml
+++ b/roles/traefik_gateway/files/gatewayclass.yaml
@@ -1,6 +1,6 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  name: traefik-gw-class
+  name: traefik
 spec:
   controllerName: traefik.io/gateway-controller

--- a/roles/traefik_gateway/files/rbac.yaml
+++ b/roles/traefik_gateway/files/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik-controller
+  namespace: traefik-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: traefik-controller
+rules:
+  - apiGroups: ['']
+    resources: ['services', 'endpoints', 'secrets']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['discovery.k8s.io']
+    resources: ['endpointslices']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['gateway.networking.k8s.io']
+    resources: ['gatewayclasses', 'gateways', 'httproutes', 'referencegrants']
+    verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: traefik-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: traefik-controller
+subjects:
+  - kind: ServiceAccount
+    name: traefik-controller
+    namespace: traefik-system

--- a/roles/traefik_gateway/files/traefik-controller.yaml
+++ b/roles/traefik_gateway/files/traefik-controller.yaml
@@ -1,59 +1,29 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: traefik
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: traefik-controller
-  namespace: traefik
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traefik
-  namespace: traefik
+  namespace: traefik-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: traefik-lb
+      app: traefik
   template:
     metadata:
       labels:
-        app: traefik-lb
+        app: traefik
     spec:
       serviceAccountName: traefik-controller
       containers:
         - name: traefik
-          image: registrii.local:5000/traefik:v2.11.7
+          image: traefik:v2.11.7
           args:
-            - --entryPoints.web.address=:80
-            - --entryPoints.websecure.address=:443
-            - --experimental.kubernetesgateway
-            - --providers.kubernetesgateway
+            - --providers.kubernetesgateway=true
+            - --entrypoints.web.address=:80
+            - --entrypoints.websecure.address=:443
+            - --providers.kubernetesgateway.controllerName=traefik.io/gateway-controller
           ports:
             - name: web
               containerPort: 80
             - name: websecure
               containerPort: 443
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: traefik
-  namespace: traefik
-spec:
-  type: LoadBalancer
-  selector:
-    app: traefik-lb
-  ports:
-    - protocol: TCP
-      port: 80
-      targetPort: web
-      name: web
-    - protocol: TCP
-      port: 443
-      targetPort: websecure
-      name: websecure

--- a/roles/traefik_gateway/tasks/main.yml
+++ b/roles/traefik_gateway/tasks/main.yml
@@ -1,45 +1,54 @@
 ---
-# Deploy Traefik Ingress controller using offline manifests
+# Deploy Traefik Gateway controller using offline manifests
 - name: Set kubectl environment
   set_fact:
     kubectl_env:
       KUBECONFIG: /etc/kubernetes/admin.conf
   become: true
 
-- name: Render Traefik manifest
-
-- name: Copy Gateway API standard CRDs
+- name: Copy Gateway API CRDs
   copy:
     src: standard-install.yaml
     dest: /tmp/standard-install.yaml
     mode: '0644'
   become: true
 
-- name: Apply standard CRDs
+- name: Apply Gateway API CRDs
   shell: kubectl apply -f /tmp/standard-install.yaml
   environment: "{{ kubectl_env }}"
   become: true
 
-- name: Copy Gateway API experimental CRDs
-  copy:
-    src: experimental-install.yaml
-    dest: /tmp/experimental-install.yaml
-    mode: '0644'
-  become: true
-
-- name: Apply experimental CRDs
-  shell: kubectl apply -f /tmp/experimental-install.yaml
+- name: Ensure traefik-system namespace exists
+  shell: |
+    cat <<EOF2 | kubectl apply -f -
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: traefik-system
+    EOF2
   environment: "{{ kubectl_env }}"
   become: true
 
-- name: Copy Traefik controller manifest
+- name: Copy Traefik RBAC manifest
+  copy:
+    src: rbac.yaml
+    dest: /tmp/traefik-rbac.yaml
+    mode: '0644'
+  become: true
+
+- name: Apply Traefik RBAC manifest
+  shell: kubectl apply -f /tmp/traefik-rbac.yaml
+  environment: "{{ kubectl_env }}"
+  become: true
+
+- name: Copy Traefik controller deployment
   copy:
     src: traefik-controller.yaml
     dest: /tmp/traefik-controller.yaml
     mode: '0644'
   become: true
 
-- name: Apply Traefik controller
+- name: Deploy Traefik controller
   shell: kubectl apply -f /tmp/traefik-controller.yaml
   environment: "{{ kubectl_env }}"
   become: true
@@ -51,7 +60,7 @@
     mode: '0644'
   become: true
 
-- name: Apply GatewayClass
+- name: Apply GatewayClass manifest
   shell: kubectl apply -f /tmp/gatewayclass.yaml
   environment: "{{ kubectl_env }}"
   become: true
@@ -63,13 +72,13 @@
     mode: '0644'
   become: true
 
-- name: Apply Gateway
+- name: Apply Gateway manifest
   shell: kubectl apply -f /tmp/gateway.yaml
   environment: "{{ kubectl_env }}"
   become: true
 
 - name: Wait for Traefik deployment rollout
-  shell: kubectl rollout status deployment/traefik -n traefik --timeout=120s
+  shell: kubectl rollout status deployment/traefik -n traefik-system --timeout=120s
   register: traefik_rollout
   retries: 5
   delay: 30


### PR DESCRIPTION
## Summary
- add Deployment-based controller manifest and RBAC resources
- update GatewayClass and Gateway manifests
- rewrite traefik_gateway tasks to apply local files and create namespace

## Testing
- `ansible-lint roles/traefik_gateway/tasks/main.yml` *(fails: command-instead-of-shell and other lint errors)*
- `yamllint roles/traefik_gateway/files/traefik-controller.yaml roles/traefik_gateway/files/gatewayclass.yaml roles/traefik_gateway/files/gateway.yaml roles/traefik_gateway/files/rbac.yaml` *(warnings: missing document start)*

------
https://chatgpt.com/codex/tasks/task_e_6878d769c434832b8efe2f0b1333e9fa