### PR TITLE
Add test route support for Traefik Gateway

### DIFF
--- a/roles/traefik_gateway/README.md
+++ b/roles/traefik_gateway/README.md
@@ -1,0 +1,20 @@
+# traefik_gateway role
+
+This role deploys Traefik Gateway in an air‑gapped Kubernetes cluster using manifests stored under `files/`.
+It applies the Gateway API CRDs, RBAC rules, controller deployment, `GatewayClass` and `Gateway` objects.
+
+Air‑gapped support is achieved by referencing images from the local registry and copying all manifests to the node before applying them with `kubectl`.
+
+## Files
+- `standard-install.yaml` – Gateway API CRDs
+- `traefik-controller.yaml` – Traefik Deployment and Service
+- `rbac.yaml` – permissions for the controller
+- `gatewayclass.yaml` – default `GatewayClass`
+- `gateway.yaml` – default `Gateway` with HTTP and HTTPS listeners
+- `whoami.yaml` – optional dummy backend service
+- `test-route.yaml` – optional `HTTPRoute` mapping to the whoami service
+
+## Customization
+Edit `gatewayclass.yaml` or `gateway.yaml` to adjust the controller name, listeners or TLS settings. These files are static and can be replaced with your own versions if different configuration is required.
+
+Set `deploy_test_route: true` to automatically deploy the `whoami` service and associated `HTTPRoute` after the controller is running. Ensure the whoami image is present in your private registry if using an air‑gapped environment.

--- a/roles/traefik_gateway/defaults/main.yml
+++ b/roles/traefik_gateway/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Default variables for the traefik_gateway role
+# Whether to deploy a sample HTTPRoute and whoami service for testing
+deploy_test_route: false

--- a/roles/traefik_gateway/files/test-route.yaml
+++ b/roles/traefik_gateway/files/test-route.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: whoami
+  namespace: default
+spec:
+  parentRefs:
+  - name: traefik-gateway
+    namespace: default
+  rules:
+  - backendRefs:
+    - name: whoami
+      kind: Service
+      port: 80

--- a/roles/traefik_gateway/files/whoami.yaml
+++ b/roles/traefik_gateway/files/whoami.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whoami
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: whoami
+  template:
+    metadata:
+      labels:
+        app: whoami
+    spec:
+      containers:
+      - name: whoami
+        image: registrii.local:5000/whoami:v1.10.1
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  namespace: default
+spec:
+  selector:
+    app: whoami
+  ports:
+  - port: 80
+    targetPort: 80

--- a/roles/traefik_gateway/tasks/main.yml
+++ b/roles/traefik_gateway/tasks/main.yml
@@ -86,3 +86,31 @@
   environment: "{{ kubectl_env }}"
   changed_when: false
   become: true
+
+- name: Copy test service manifest
+  copy:
+    src: whoami.yaml
+    dest: /tmp/whoami.yaml
+    mode: '0644'
+  when: deploy_test_route
+  become: true
+
+- name: Apply test service manifest
+  shell: kubectl apply -f /tmp/whoami.yaml
+  environment: "{{ kubectl_env }}"
+  when: deploy_test_route
+  become: true
+
+- name: Copy test HTTPRoute manifest
+  copy:
+    src: test-route.yaml
+    dest: /tmp/test-route.yaml
+    mode: '0644'
+  when: deploy_test_route
+  become: true
+
+- name: Apply test HTTPRoute manifest
+  shell: kubectl apply -f /tmp/test-route.yaml
+  environment: "{{ kubectl_env }}"
+  when: deploy_test_route
+  become: true


### PR DESCRIPTION
## Summary
- add defaults to enable optional test HTTPRoute
- include whoami backend and route manifests
- update tasks to deploy the test service when enabled
- document the traefik_gateway role

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6878d919c704832ba5109fbaef66711e