### PR TITLE
Add Traefik Gateway role

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ CustomResourceDefinitions and waits until the `FelixConfiguration` CRD becomes
 available before applying the rest of the resources. This avoids failures that
 can occur when the API server has not yet processed the CRDs during the initial
 apply.
+
+The `traefik_gateway` role deploys a Traefik Gateway controller and related
+Gateway API resources. All manifests use container images from the local
+registry so the gateway can be installed entirely offline.

--- a/roles/traefik_gateway/files/traefik-controller.yaml
+++ b/roles/traefik_gateway/files/traefik-controller.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: traefik-controller
       containers:
         - name: traefik
-          image: traefik:v2.11.7
+          image: registrii.local:5000/traefik:v2.11.7
           args:
             - --providers.kubernetesgateway=true
             - --entrypoints.web.address=:80

--- a/site.yml
+++ b/site.yml
@@ -42,5 +42,12 @@
   any_errors_fatal: true
   run_once: true
   roles:
+    - role: traefik_gateway
+
+- hosts: masters
+  become: yes
+  any_errors_fatal: true
+  run_once: true
+  roles:
     - role: post_install_checks
 


### PR DESCRIPTION
## Summary
- include `traefik_gateway` role in the playbook
- use offline Traefik image in controller manifest
- document Traefik Gateway role in README

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6878dae1d02c832b9fe1ad71382f3cc4