### PR TITLE
Add cunofs CSI driver role skeleton

### DIFF
--- a/roles/cunofs-csi-driver/README.md
+++ b/roles/cunofs-csi-driver/README.md
@@ -1,0 +1,6 @@
+# cunofs-csi-driver role
+
+This role deploys the cunofs CSI driver in an air-gapped Kubernetes cluster.
+All manifests are stored under `files/` and reference images from the local registry.
+Adjust `cunofs_controller_image` and `cunofs_node_image` in `defaults/main.yml`
+to match your environment.

--- a/roles/cunofs-csi-driver/defaults/main.yml
+++ b/roles/cunofs-csi-driver/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Default variables for cunofs-csi-driver role
+# Set the image registry and tags to match your offline registry
+cunofs_controller_image: "registry.local/cunofs/csi-controller:latest"
+cunofs_node_image: "registry.local/cunofs/csi-node:latest"

--- a/roles/cunofs-csi-driver/files/csi-controller.yaml
+++ b/roles/cunofs-csi-driver/files/csi-controller.yaml
@@ -1,0 +1,21 @@
+# Placeholder controller Deployment for cunofs CSI driver
+# Replace image with one hosted in your private registry
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cunofs-csi-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cunofs-csi-controller
+  template:
+    metadata:
+      labels:
+        app: cunofs-csi-controller
+    spec:
+      containers:
+        - name: csi-controller
+          image: registry.local/cunofs/csi-controller:latest
+          args: []

--- a/roles/cunofs-csi-driver/files/csi-node.yaml
+++ b/roles/cunofs-csi-driver/files/csi-node.yaml
@@ -1,0 +1,20 @@
+# Placeholder DaemonSet for cunofs CSI node plugin
+# Replace image with one hosted in your private registry
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cunofs-csi-node
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: cunofs-csi-node
+  template:
+    metadata:
+      labels:
+        app: cunofs-csi-node
+    spec:
+      containers:
+        - name: csi-node
+          image: registry.local/cunofs/csi-node:latest
+          args: []

--- a/roles/cunofs-csi-driver/files/storageclass.yaml
+++ b/roles/cunofs-csi-driver/files/storageclass.yaml
@@ -1,0 +1,8 @@
+# Placeholder StorageClass definition for cunofs
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cunofs-sc
+provisioner: csi.cunofs.com
+parameters:
+  type: default

--- a/roles/cunofs-csi-driver/tasks/main.yml
+++ b/roles/cunofs-csi-driver/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+# Deploy the cunofs CSI driver using offline manifests
+- name: Set kubectl environment
+  set_fact:
+    kubectl_env:
+      KUBECONFIG: /etc/kubernetes/admin.conf
+  become: true
+
+- name: Copy cunofs controller manifest
+  copy:
+    src: csi-controller.yaml
+    dest: /tmp/cunofs-csi-controller.yaml
+    mode: '0644'
+  become: true
+
+- name: Apply cunofs controller manifest
+  shell: kubectl apply -f /tmp/cunofs-csi-controller.yaml
+  environment: "{{ kubectl_env }}"
+  become: true
+
+- name: Copy cunofs node manifest
+  copy:
+    src: csi-node.yaml
+    dest: /tmp/cunofs-csi-node.yaml
+    mode: '0644'
+  become: true
+
+- name: Apply cunofs node manifest
+  shell: kubectl apply -f /tmp/cunofs-csi-node.yaml
+  environment: "{{ kubectl_env }}"
+  become: true
+
+- name: Copy storage class manifest
+  copy:
+    src: storageclass.yaml
+    dest: /tmp/cunofs-storageclass.yaml
+    mode: '0644'
+  become: true
+
+- name: Apply storage class manifest
+  shell: kubectl apply -f /tmp/cunofs-storageclass.yaml
+  environment: "{{ kubectl_env }}"
+  become: true


### PR DESCRIPTION
## Summary
- add `cunofs-csi-driver` role with offline manifests
- include placeholder controller, node and storage class YAMLs

## Testing
- `ansible-playbook site.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6878df73b978832b9d33f8bb217b1264