### PR TITLE
Add cunofs CSI chart fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ The `traefik_gateway` role deploys a Traefik Gateway controller and related
 Gateway API resources. All manifests use container images from the local
 registry so the gateway can be installed entirely offline.
 
+`scripts/fetch_offline_assets.sh` also downloads the cunoFS CSI Helm chart and
+its container images. The chart is extracted under
+`roles/cunofs-csi-driver/files/chart` and the tarred images are saved in
+`offline_image_dir` alongside the other archives.
+

--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -189,6 +189,23 @@ docker pull nvcr.io/nvidia/k8s-device-plugin:${device_plugin_version}
 docker save nvcr.io/nvidia/k8s-device-plugin:${device_plugin_version} \
   -o nvidia-device-plugin_${device_plugin_version}.tar
 
+# cunoFS CSI Helm chart and images
+chart_dir="$ROOT_DIR/roles/cunofs-csi-driver/files/chart"
+mkdir -p "$chart_dir"
+helm pull --untar oci://registry-1.docker.io/cunofs/cunofs-csi-chart -d "$chart_dir"
+
+cunofs_images=(
+  "docker.io/cunofs/csi-controller:latest"
+  "docker.io/cunofs/csi-node:latest"
+)
+for img in "${cunofs_images[@]}"; do
+  base="$(basename "$img")"
+  file="${base/:/_}.tar"
+  docker pull "$img"
+  docker save "$img" -o "$file"
+  echo "Saved $img to $file"
+done
+
 # Calico manifest
 curl -L \
   -o calico.yaml \


### PR DESCRIPTION
## Summary
- download cunofs CSI chart and images in fetch script
- document cunofs chart and images in README

## Testing
- `bash -n scripts/fetch_offline_assets.sh`
- `python3 -m py_compile scripts/serve_assets.py`


------
https://chatgpt.com/codex/tasks/task_e_6878e12f060c832bb1098511de62ef5e