### PR TITLE
Fix join command generation race

### DIFF
--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -32,6 +32,15 @@
       changed_when: false
       become: true
 
+    - name: Wait for API server to be reachable
+      shell: kubectl --kubeconfig /etc/kubernetes/admin.conf get --raw=/healthz
+      register: apiserver_status
+      retries: 20
+      delay: 5
+      until: apiserver_status.rc == 0
+      changed_when: false
+      become: true
+
     - name: Generate base join command for control plane
       shell: kubeadm token create --print-join-command
       register: base_join_cmd


### PR DESCRIPTION
## Summary
- wait for kube-apiserver to respond before generating kubeadm join commands

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6878e10f00c4832bb64c0d0cae27636f