### PR TITLE
Add cunofs license secret handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ its container images. The chart is extracted under
 `roles/cunofs-csi-driver/files/chart` and the tarred images are saved in
 `offline_image_dir` alongside the other archives.
 
+Provide the cunoFS license key via the `cunofs_license_key` variable to
+generate a `cunofs-license` Secret during deployment.
+

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -59,3 +59,6 @@ nvidia_packages:
 # Hosts file configuration
 add_registry_host_entry: true            # Whether to map registry_host in /etc/hosts
 registry_master_ip: "10.0.1.103"                  # Override master IP for registry host if needed
+
+# cunoFS license key
+cunofs_license_key: ""

--- a/roles/cunofs-csi-driver/tasks/main.yml
+++ b/roles/cunofs-csi-driver/tasks/main.yml
@@ -6,6 +6,18 @@
       KUBECONFIG: /etc/kubernetes/admin.conf
   become: true
 
+- name: Render cunofs license secret manifest
+  template:
+    src: license-secret.yaml.j2
+    dest: /tmp/cunofs-license.yaml
+    mode: '0644'
+  become: true
+
+- name: Apply cunofs license secret
+  shell: kubectl apply -f /tmp/cunofs-license.yaml
+  environment: "{{ kubectl_env }}"
+  become: true
+
 - name: Copy cunofs controller manifest
   copy:
     src: csi-controller.yaml

--- a/roles/cunofs-csi-driver/templates/license-secret.yaml.j2
+++ b/roles/cunofs-csi-driver/templates/license-secret.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cunofs-license
+  namespace: kube-system
+type: Opaque
+data:
+  license: "{{ cunofs_license_key | b64encode }}"


### PR DESCRIPTION
## Summary
- generate cunofs license secret via template
- apply the secret during the cunofs-csi-driver role
- document `cunofs_license_key` variable

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6878e23b246c832bb215e4e06dec8791