### PR TITLE
Fix kubeadm init rerun

### DIFF
--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -11,6 +11,11 @@
   register: kubelet_conf
   become: true
 
+- name: Reset previous Kubernetes state if present
+  shell: kubeadm reset -f
+  when: not kubelet_conf.stat.exists
+  become: true
+
 - block:
     - name: Generate kubeadm configuration
       template:

--- a/roles/kubeadm_workers/tasks/main.yml
+++ b/roles/kubeadm_workers/tasks/main.yml
@@ -7,6 +7,11 @@
   register: kubelet_conf
   become: yes
 
+- name: Reset previous Kubernetes state if present
+  shell: kubeadm reset -f
+  when: not kubelet_conf.stat.exists
+  become: yes
+
 - name: Get join command from master
   command: cat /tmp/join.sh
   register: master_join_cmd


### PR DESCRIPTION
## Summary
- add kubeadm reset step for masters and workers

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6878e43111c8832ba7b09dfe2be5f517