### PR TITLE
Add helm templating step for cunoFS CSI

### DIFF
--- a/roles/cunofs-csi-driver/README.md
+++ b/roles/cunofs-csi-driver/README.md
@@ -1,6 +1,8 @@
 # cunofs-csi-driver role
 
-This role deploys the cunofs CSI driver in an air-gapped Kubernetes cluster.
-All manifests are stored under `files/` and reference images from the local registry.
-Adjust `cunofs_controller_image` and `cunofs_node_image` in `defaults/main.yml`
-to match your environment.
+This role deploys the cunoFS CSI driver in an air‑gapped Kubernetes cluster.
+It can render the bundled Helm chart using `helm template` and apply the
+generated manifests locally. The chart is expected to be present under
+`files/chart` which is populated by `scripts/fetch_offline_assets.sh`.
+Images reference the local registry and can be tuned via
+`defaults/main.yml`.

--- a/roles/cunofs-csi-driver/tasks/main.yml
+++ b/roles/cunofs-csi-driver/tasks/main.yml
@@ -6,6 +6,16 @@
       KUBECONFIG: /etc/kubernetes/admin.conf
   become: true
 
+- name: Deploy cunofs CSI driver via Helm
+  shell: >
+    helm template cunofs {{ role_path }}/files/chart/cunofs-csi-chart
+    --set license={{ cunofs_license_key | quote }} |
+    kubectl apply -f -
+  args:
+    chdir: "{{ role_path }}"
+  environment: "{{ kubectl_env }}"
+  become: true
+
 - name: Render cunofs license secret manifest
   template:
     src: license-secret.yaml.j2


### PR DESCRIPTION
## Summary
- render and apply cunoFS CSI chart with a license override via Helm
- document Helm-based deployment for the CSI driver

## Testing
- `ansible-playbook --syntax-check site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e40f7f6c832ba7f973e525837b3b