### PR TITLE
Fix kubeadm token creation path

### DIFF
--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -47,7 +47,7 @@
       become: true
 
     - name: Generate base join command for control plane
-      shell: kubeadm token create --print-join-command
+      shell: kubeadm token create --kubeconfig /etc/kubernetes/admin.conf --print-join-command
       register: base_join_cmd
       changed_when: false
       become: true
@@ -57,7 +57,7 @@
         cp_join_cmd: "{{ base_join_cmd.stdout }} --control-plane --certificate-key {{ cert_key.stdout }}"
 
     - name: Generate join command for workers
-      shell: kubeadm token create --print-join-command
+      shell: kubeadm token create --kubeconfig /etc/kubernetes/admin.conf --print-join-command
       register: worker_join_cmd
       changed_when: false
       become: true


### PR DESCRIPTION
## Summary
- ensure `kubeadm token create` uses the admin kubeconfig when generating
  join commands

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878e5d8dd94832b8ed272a68b861c42