### PR TITLE
Fix Traefik flag

### DIFF
--- a/roles/traefik_gateway/files/traefik-controller.yaml
+++ b/roles/traefik_gateway/files/traefik-controller.yaml
@@ -21,7 +21,6 @@ spec:
             - --providers.kubernetesgateway=true
             - --entrypoints.web.address=:80
             - --entrypoints.websecure.address=:443
-            - --providers.kubernetesgateway.controllerName=traefik.io/gateway-controller
           ports:
             - name: web
               containerPort: 80


### PR DESCRIPTION
## Summary
- remove `--providers.kubernetesgateway.controllerName` from Traefik deployment

## Testing
- `ansible-lint` *(fails: command not found)*
- `ansible-playbook --syntax-check site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ec3d18e0832babb2fb0903586e2b