### PR TITLE
Restart kubelet after kubeadm roles

### DIFF
--- a/roles/kubeadm_master/handlers/main.yml
+++ b/roles/kubeadm_master/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart kubelet
+  service:
+    name: kubelet
+    state: restarted
+  become: yes

--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -167,3 +167,9 @@
       changed_when: false
       become: true
   when: is_first_master
+
+- name: Schedule kubelet restart
+  command: /bin/true
+  notify: Restart kubelet
+  changed_when: false
+  become: yes

--- a/roles/kubeadm_workers/handlers/main.yml
+++ b/roles/kubeadm_workers/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart kubelet
+  service:
+    name: kubelet
+    state: restarted
+  become: yes

--- a/roles/kubeadm_workers/tasks/main.yml
+++ b/roles/kubeadm_workers/tasks/main.yml
@@ -40,3 +40,9 @@
     - not kubelet_conf.stat.exists
     - join_result.rc == 0
   become: yes
+
+- name: Schedule kubelet restart
+  command: /bin/true
+  notify: Restart kubelet
+  changed_when: false
+  become: yes


### PR DESCRIPTION
## Summary
- restart kubelet after cluster install
- add handlers for master and worker roles

## Testing
- `ansible-lint -v` *(fails: 1139 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6878ecb3c260832b8c45f829b8ddaff1