### PR TITLE
Restart kubelet earlier

### DIFF
--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -126,6 +126,12 @@
   when: kubelet_conf.stat.exists
   become: true
 
+- name: Schedule kubelet restart
+  command: /bin/true
+  notify: Restart kubelet
+  changed_when: false
+  become: yes
+
 - block:
     - name: Download Calico manifest from asset server
       get_url:
@@ -168,8 +174,3 @@
       become: true
   when: is_first_master
 
-- name: Schedule kubelet restart
-  command: /bin/true
-  notify: Restart kubelet
-  changed_when: false
-  become: yes


### PR DESCRIPTION
## Summary
- schedule kubelet restart before Calico manifest is applied

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6878f4249804832b907385c82580704a