### PR TITLE
Add cunoFS CSI role

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,8 @@ Provide the cunoFS license key via the `cunofs_license_key` variable to
 generate a `cunofs-license` Secret during deployment. The driver manifests
 will be installed into the namespace specified by `cunofs_namespace`.
 
+After Traefik is set up, the playbook automatically runs the
+`cunofs-csi-driver` role to deploy the cunoFS CSI driver from the locally
+extracted Helm chart. This step requires no internet access and completes the
+offline Kubernetes installation.
+

--- a/site.yml
+++ b/site.yml
@@ -49,5 +49,12 @@
   any_errors_fatal: true
   run_once: true
   roles:
+    - role: cunofs-csi-driver
+
+- hosts: masters
+  become: yes
+  any_errors_fatal: true
+  run_once: true
+  roles:
     - role: post_install_checks
 


### PR DESCRIPTION
## Summary
- include the `cunofs-csi-driver` role in the playbook
- document CSI driver deployment in README

## Testing
- `ansible-playbook -i inventory --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6878f435766c832bafca582953362e16