### PR TITLE
Add sample_app role to deploy simple test application

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ The `traefik_gateway` role deploys a Traefik Gateway controller and related
 Gateway API resources. All manifests use container images from the local
 registry so the gateway can be installed entirely offline.
 
+The `sample_app` role provides a minimal Deployment, Service and HTTPRoute that
+use only local manifests and images. It allows quick end‑to‑end testing of the
+cluster once the gateway is running.
+
 `scripts/fetch_offline_assets.sh` also downloads the cunoFS CSI Helm chart and
 its container images. The chart is extracted under
 `roles/cunofs-csi-driver/files/chart` and the tarred images are saved in

--- a/roles/sample_app/README.md
+++ b/roles/sample_app/README.md
@@ -1,0 +1,6 @@
+# sample_app role
+
+This role deploys a minimal HTTP application using only local manifests so it works fully offline.
+It creates a Deployment, Service and HTTPRoute to expose the pod through the Traefik gateway.
+
+The container image and resource names can be customised in `defaults/main.yml`.

--- a/roles/sample_app/defaults/main.yml
+++ b/roles/sample_app/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Default variables for sample_app
+sample_app_name: echo-app
+sample_app_namespace: default
+sample_app_image: "{{ registry_host }}:{{ registry_port }}/nginx:1.25"
+gateway_name: traefik-gateway

--- a/roles/sample_app/tasks/main.yml
+++ b/roles/sample_app/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+# Deploy a simple application using offline manifests
+- name: Set kubectl environment
+  set_fact:
+    kubectl_env:
+      KUBECONFIG: /etc/kubernetes/admin.conf
+  become: true
+
+- name: Render deployment manifest
+  template:
+    src: deployment.yaml.j2
+    dest: /tmp/{{ sample_app_name }}-deployment.yaml
+    mode: '0644'
+  become: true
+
+- name: Apply deployment manifest
+  shell: kubectl apply -f /tmp/{{ sample_app_name }}-deployment.yaml
+  environment: "{{ kubectl_env }}"
+  become: true
+
+- name: Render service manifest
+  template:
+    src: service.yaml.j2
+    dest: /tmp/{{ sample_app_name }}-service.yaml
+    mode: '0644'
+  become: true
+
+- name: Apply service manifest
+  shell: kubectl apply -f /tmp/{{ sample_app_name }}-service.yaml
+  environment: "{{ kubectl_env }}"
+  become: true
+
+- name: Render HTTPRoute manifest
+  template:
+    src: httproute.yaml.j2
+    dest: /tmp/{{ sample_app_name }}-httproute.yaml
+    mode: '0644'
+  become: true
+
+- name: Apply HTTPRoute manifest
+  shell: kubectl apply -f /tmp/{{ sample_app_name }}-httproute.yaml
+  environment: "{{ kubectl_env }}"
+  become: true
+
+- name: Wait for application deployment rollout
+  shell: kubectl rollout status deployment/{{ sample_app_name }} -n {{ sample_app_namespace }} --timeout=120s
+  register: app_rollout
+  retries: 5
+  delay: 30
+  until: app_rollout.rc == 0
+  environment: "{{ kubectl_env }}"
+  changed_when: false
+  become: true

--- a/roles/sample_app/templates/deployment.yaml.j2
+++ b/roles/sample_app/templates/deployment.yaml.j2
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ sample_app_name }}
+  namespace: {{ sample_app_namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ sample_app_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ sample_app_name }}
+    spec:
+      containers:
+      - name: {{ sample_app_name }}
+        image: {{ sample_app_image }}
+        ports:
+        - containerPort: 80

--- a/roles/sample_app/templates/httproute.yaml.j2
+++ b/roles/sample_app/templates/httproute.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ sample_app_name }}
+  namespace: {{ sample_app_namespace }}
+spec:
+  parentRefs:
+  - name: {{ gateway_name }}
+    namespace: {{ sample_app_namespace }}
+  rules:
+  - backendRefs:
+    - name: {{ sample_app_name }}
+      kind: Service
+      port: 80

--- a/roles/sample_app/templates/service.yaml.j2
+++ b/roles/sample_app/templates/service.yaml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ sample_app_name }}
+  namespace: {{ sample_app_namespace }}
+spec:
+  selector:
+    app: {{ sample_app_name }}
+  ports:
+  - port: 80
+    targetPort: 80

--- a/site.yml
+++ b/site.yml
@@ -49,5 +49,12 @@
   any_errors_fatal: true
   run_once: true
   roles:
+    - role: sample_app
+
+- hosts: masters
+  become: yes
+  any_errors_fatal: true
+  run_once: true
+  roles:
     - role: post_install_checks
 


### PR DESCRIPTION
## Summary
- add `sample_app` Ansible role to deploy a minimal Deployment, Service and HTTPRoute
- call the new role in `site.yml`
- document the role in the main README

## Testing
- `ansible-playbook -i inventory --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6878f4b46a74832babc7df4bd5d900df