### PR TITLE
Add offline python web server sample app

### DIFF
--- a/roles/sample_app/README.md
+++ b/roles/sample_app/README.md
@@ -1,6 +1,6 @@
 # sample_app role
 
-This role deploys a minimal HTTP application using only local manifests so it works fully offline.
-It creates a Deployment, Service and HTTPRoute to expose the pod through the Traefik gateway.
+This role deploys a minimal Python HTTP server using local manifests so it works fully offline.
+It creates a ConfigMap with an `index.html`, a Deployment running `python -m http.server`, a Service and an HTTPRoute to expose the pod through the Traefik gateway.
 
-The container image and resource names can be customised in `defaults/main.yml`.
+The container image, content and resource names can be customised in `defaults/main.yml`.

--- a/roles/sample_app/defaults/main.yml
+++ b/roles/sample_app/defaults/main.yml
@@ -2,5 +2,13 @@
 # Default variables for sample_app
 sample_app_name: echo-app
 sample_app_namespace: default
-sample_app_image: "{{ registry_host }}:{{ registry_port }}/nginx:1.25"
+sample_app_image: "{{ registry_host }}:{{ registry_port }}/python:3.12-alpine"
+sample_app_index_content: |
+  <!doctype html>
+  <html>
+    <body>
+      <h1>Sample App</h1>
+      <p>This is a simple Python web server.</p>
+    </body>
+  </html>
 gateway_name: traefik-gateway

--- a/roles/sample_app/tasks/main.yml
+++ b/roles/sample_app/tasks/main.yml
@@ -1,9 +1,21 @@
 ---
-# Deploy a simple application using offline manifests
+# Deploy a simple web server using offline manifests
 - name: Set kubectl environment
   set_fact:
     kubectl_env:
       KUBECONFIG: /etc/kubernetes/admin.conf
+  become: true
+
+- name: Render web content ConfigMap
+  template:
+    src: configmap.yaml.j2
+    dest: /tmp/{{ sample_app_name }}-configmap.yaml
+    mode: '0644'
+  become: true
+
+- name: Apply web content ConfigMap
+  shell: kubectl apply -f /tmp/{{ sample_app_name }}-configmap.yaml
+  environment: "{{ kubectl_env }}"
   become: true
 
 - name: Render deployment manifest

--- a/roles/sample_app/templates/configmap.yaml.j2
+++ b/roles/sample_app/templates/configmap.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ sample_app_name }}-content
+  namespace: {{ sample_app_namespace }}
+data:
+  index.html: |
+    {{ sample_app_index_content | indent(4) }}

--- a/roles/sample_app/templates/deployment.yaml.j2
+++ b/roles/sample_app/templates/deployment.yaml.j2
@@ -13,8 +13,17 @@ spec:
       labels:
         app: {{ sample_app_name }}
     spec:
+      volumes:
+      - name: content
+        configMap:
+          name: {{ sample_app_name }}-content
       containers:
       - name: {{ sample_app_name }}
         image: {{ sample_app_image }}
+        command: ["python3", "-m", "http.server", "80"]
+        workingDir: /usr/share/{{ sample_app_name }}
+        volumeMounts:
+        - name: content
+          mountPath: /usr/share/{{ sample_app_name }}
         ports:
         - containerPort: 80

--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -88,6 +88,7 @@
       - "kube-controllers_{{ calico_image_version }}.tar"
     nvidia_plugin_image: "nvidia-device-plugin_{{ device_plugin_version }}.tar"
     traefik_image: "traefik_v{{ traefik_version }}.tar"
+    python_image: "python_3.12-alpine.tar"
 
 # Download Kubernetes core image tarballs
 - name: Download Kubernetes core images
@@ -165,6 +166,25 @@
 - name: Load and push Traefik image
   shell: |
     img=$(docker load -i /tmp/{{ traefik_image }} | awk '/Loaded image:/ {print $3}')
+    name=$(echo "$img" | awk -F/ '{print $NF}')
+    docker tag $img {{ registry_host }}:{{ registry_port }}/$name
+    docker push {{ registry_host }}:{{ registry_port }}/$name
+  args:
+    executable: /bin/bash
+  become: yes
+
+# Python image for the sample application
+- name: Download Python image for sample app
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/images/{{ python_image }}"
+    dest: "/tmp/{{ python_image }}"
+    mode: '0644'
+    timeout: 60
+  become: yes
+
+- name: Load and push Python image
+  shell: |
+    img=$(docker load -i /tmp/{{ python_image }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
     docker tag $img {{ registry_host }}:{{ registry_port }}/$name
     docker push {{ registry_host }}:{{ registry_port }}/$name

--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -180,6 +180,10 @@ done
 docker pull traefik:v${traefik_version}
 docker save traefik:v${traefik_version} -o "traefik_v${traefik_version}.tar"
 
+# Python image for the sample application
+docker pull python:3.12-alpine
+docker save python:3.12-alpine -o python_3.12-alpine.tar
+
 # Calico images
 calico_images=(
   "docker.io/calico/cni:${calico_image_version}"


### PR DESCRIPTION
## Summary
- update sample_app role to deploy a Python-based HTTP server
- add ConfigMap with index.html content
- fetch and load Python image for offline registry
- update offline assets script

## Testing
- `ansible-playbook --syntax-check site.yml`
- `ansible-lint` *(fails: 1187 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6878feb48f08832b8ef3d2f71d63b0ed