### PR TITLE
Fix traefik host ports

### DIFF
--- a/roles/traefik_gateway/README.md
+++ b/roles/traefik_gateway/README.md
@@ -7,7 +7,8 @@ Air‑gapped support is achieved by referencing images from the local registry a
 
 ## Files
 - `standard-install.yaml` – Gateway API CRDs
-- `traefik-controller.yaml` – Traefik Deployment and Service
+- `traefik-controller.yaml` – Traefik Deployment using `hostNetwork` so that
+  the node listens directly on ports 80 and 443
 - `rbac.yaml` – permissions for the controller
 - `gatewayclass.yaml` – default `GatewayClass`
 - `gateway.yaml` – default `Gateway` with HTTP and HTTPS listeners

--- a/roles/traefik_gateway/files/traefik-controller.yaml
+++ b/roles/traefik_gateway/files/traefik-controller.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,6 +14,8 @@ spec:
       labels:
         app: traefik
     spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: traefik-controller
       containers:
         - name: traefik


### PR DESCRIPTION
## Summary
- expose traefik on host ports by setting `hostNetwork: true`
- update documentation about the new exposure

## Testing
- `yamllint roles/traefik_gateway/files/traefik-controller.yaml`
- `ansible-lint roles/traefik_gateway/tasks/main.yml` *(fails: 34 violation(s))*

------
https://chatgpt.com/codex/tasks/task_e_68790b604e0c832b8d309b1a8bbe79fc