### PR TITLE
Deploy Traefik on every node

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ apply.
 
 
 The `traefik_gateway` role deploys a Traefik Gateway controller and related
-Gateway API resources. All manifests use container images from the local
-registry so the gateway can be installed entirely offline.
+Gateway API resources. Traefik runs as a DaemonSet so every node exposes ports
+80 and 443. All manifests use container images from the local registry so the
+gateway can be installed entirely offline.
 
 The `sample_app` role provides a minimal Deployment, Service and HTTPRoute that
 use only local manifests and images. It allows quick end‑to‑end testing of the

--- a/roles/traefik_gateway/README.md
+++ b/roles/traefik_gateway/README.md
@@ -1,14 +1,14 @@
 # traefik_gateway role
 
 This role deploys Traefik Gateway in an air‑gapped Kubernetes cluster using manifests stored under `files/`.
-It applies the Gateway API CRDs, RBAC rules, controller deployment, `GatewayClass` and `Gateway` objects.
+It applies the Gateway API CRDs, RBAC rules, controller DaemonSet, `GatewayClass` and `Gateway` objects.
 
 Air‑gapped support is achieved by referencing images from the local registry and copying all manifests to the node before applying them with `kubectl`.
 
 ## Files
 - `standard-install.yaml` – Gateway API CRDs
-- `traefik-controller.yaml` – Traefik Deployment using `hostNetwork` so that
-  the node listens directly on ports 80 and 443
+- `traefik-controller.yaml` – Traefik DaemonSet using `hostNetwork` so that
+  every node listens directly on ports 80 and 443
 - `rbac.yaml` – permissions for the controller
 - `gatewayclass.yaml` – default `GatewayClass`
 - `gateway.yaml` – default `Gateway` with HTTP and HTTPS listeners

--- a/roles/traefik_gateway/files/traefik-controller.yaml
+++ b/roles/traefik_gateway/files/traefik-controller.yaml
@@ -1,11 +1,10 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: traefik
   namespace: traefik-system
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: traefik

--- a/roles/traefik_gateway/tasks/main.yml
+++ b/roles/traefik_gateway/tasks/main.yml
@@ -77,8 +77,8 @@
   environment: "{{ kubectl_env }}"
   become: true
 
-- name: Wait for Traefik deployment rollout
-  shell: kubectl rollout status deployment/traefik -n traefik-system --timeout=120s
+- name: Wait for Traefik daemonset rollout
+  shell: kubectl rollout status daemonset/traefik -n traefik-system --timeout=120s
   register: traefik_rollout
   retries: 5
   delay: 30


### PR DESCRIPTION
## Summary
- run Traefik as a DaemonSet so each node handles ingress
- document the DaemonSet in the Traefik role and main README
- update rollout task to wait for daemonset

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6879126d2864832bb0d0f59473d195cc