### PR TITLE
Fix nvidia image tag

### DIFF
--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -147,7 +147,9 @@
 - name: Load and push NVIDIA device plugin image
   shell: |
     img=$(docker load -i /tmp/{{ nvidia_plugin_image }} | awk '/Loaded image:/ {print $3}')
-    name=$(echo "$img" | awk -F/ '{print $NF}')
+    # Preserve the repository path so the image is available as
+    # <registry_host>:<registry_port>/nvidia/k8s-device-plugin:<tag>
+    name=$(echo "$img" | cut -d/ -f2-)
     docker tag $img {{ registry_host }}:{{ registry_port }}/$name
     docker push {{ registry_host }}:{{ registry_port }}/$name
   args:


### PR DESCRIPTION
## Summary
- fix tag for NVIDIA plugin image so the repository path is preserved

## Testing
- `ansible-playbook --syntax-check -i inventory site.yml`
- `ansible-lint` *(fails: Truthy value should be one of [false, true])*

------
https://chatgpt.com/codex/tasks/task_e_687912c67ee0832bbb4c7a37acab1827