### PR TITLE
Load cunoFS images into registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ its container images. The chart is extracted under
 Image references inside the chart are rewritten to use the
 `registry_host`/`registry_port` settings so the manifests can be applied
 fully offline.
+The `setup_registry` role loads these cunoFS image tarballs and pushes the
+images to the local registry so the driver can start without external access.
 The Helm version used for fetching can be customised via the
 `helm_version` variable in `group_vars/all.yml`.
 

--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -89,6 +89,9 @@
     nvidia_plugin_image: "nvidia-device-plugin_{{ device_plugin_version }}.tar"
     traefik_image: "traefik_v{{ traefik_version }}.tar"
     python_image: "python_3.12-alpine.tar"
+    cunofs_images:
+      - "csi-controller_latest.tar"
+      - "csi-node_latest.tar"
 
 # Download Kubernetes core image tarballs
 - name: Download Kubernetes core images
@@ -190,6 +193,27 @@
     docker push {{ registry_host }}:{{ registry_port }}/$name
   args:
     executable: /bin/bash
+  become: yes
+
+# cunoFS CSI driver images
+- name: Download cunoFS images
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/images/{{ item }}"
+    dest: "/tmp/{{ item }}"
+    mode: '0644'
+    timeout: 60
+  loop: "{{ cunofs_images }}"
+  become: yes
+
+- name: Load and push cunoFS images
+  shell: |
+    img=$(docker load -i /tmp/{{ item }} | awk '/Loaded image:/ {print $3}')
+    name=$(echo "$img" | awk -F/ '{print $(NF-1) "/" $NF}')
+    docker tag $img {{ registry_host }}:{{ registry_port }}/$name
+    docker push {{ registry_host }}:{{ registry_port }}/$name
+  args:
+    executable: /bin/bash
+  loop: "{{ cunofs_images }}"
   become: yes
 
 # Optional verification that the registry is serving


### PR DESCRIPTION
## Summary
- push cunoFS CSI driver images to the local registry
- mention registry role handling of cunoFS images in README

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_687912badbdc832b85dc94efe5aad80d