### PR TITLE
Load whoami image for Traefik test route

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ The `sample_app` role provides a minimal Deployment, Service and HTTPRoute that
 use only local manifests and images. It allows quick end‑to‑end testing of the
 cluster once the gateway is running.
 
+`scripts/fetch_offline_assets.sh` now also saves the `traefik/whoami` image
+used by the optional test route so the gateway can serve traffic without
+external access.
+
 `scripts/fetch_offline_assets.sh` also downloads the cunoFS CSI Helm chart and
 its container images. The chart is extracted under
 `roles/cunofs-csi-driver/files/chart` and the tarred images are saved in

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -38,6 +38,7 @@ offline_image_dir: "/opt/offline/images" # Location of saved container images
 calico_version: "v3.27.2"           # Manifest version
 calico_image_version: "v3.27.2"    # Container image tag
 traefik_version: "2.11.7"          # Traefik image tag
+whoami_version: "v1.10.1"          # traefik/whoami image tag used for tests
 helm_version: "v3.18.4"            # Helm CLI version used when fetching assets
 
 # Private registry settings

--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -89,6 +89,7 @@
     nvidia_plugin_image: "nvidia-device-plugin_{{ device_plugin_version }}.tar"
     traefik_image: "traefik_v{{ traefik_version }}.tar"
     python_image: "python_3.12-alpine.tar"
+    whoami_image: "whoami_{{ whoami_version }}.tar"
     cunofs_images:
       - "csi-controller_latest.tar"
       - "csi-node_latest.tar"
@@ -190,6 +191,25 @@
 - name: Load and push Python image
   shell: |
     img=$(docker load -i /tmp/{{ python_image }} | awk '/Loaded image:/ {print $3}')
+    name=$(echo "$img" | awk -F/ '{print $NF}')
+    docker tag $img {{ registry_host }}:{{ registry_port }}/$name
+    docker push {{ registry_host }}:{{ registry_port }}/$name
+  args:
+    executable: /bin/bash
+  become: yes
+
+# whoami image for the traefik test service
+- name: Download whoami image
+  get_url:
+    url: "http://{{ asset_server_host }}:{{ asset_server_port }}/images/{{ whoami_image }}"
+    dest: "/tmp/{{ whoami_image }}"
+    mode: '0644'
+    timeout: 60
+  become: yes
+
+- name: Load and push whoami image
+  shell: |
+    img=$(docker load -i /tmp/{{ whoami_image }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
     docker tag $img {{ registry_host }}:{{ registry_port }}/$name
     docker push {{ registry_host }}:{{ registry_port }}/$name

--- a/roles/traefik_gateway/README.md
+++ b/roles/traefik_gateway/README.md
@@ -18,4 +18,7 @@ Air‑gapped support is achieved by referencing images from the local registry a
 ## Customization
 Edit `gatewayclass.yaml` or `gateway.yaml` to adjust the controller name, listeners or TLS settings. These files are static and can be replaced with your own versions if different configuration is required.
 
-Set `deploy_test_route: true` to automatically deploy the `whoami` service and associated `HTTPRoute` after the controller is running. Ensure the whoami image is present in your private registry if using an air‑gapped environment.
+Set `deploy_test_route: true` to automatically deploy the `whoami` service and
+associated `HTTPRoute` after the controller is running. The
+`scripts/fetch_offline_assets.sh` helper downloads this image so it can be
+loaded into the local registry during `setup_registry`.

--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -26,14 +26,14 @@ fi
 
 read -r offline_pkg_dir offline_image_dir kube_version kube_version_pkgs \
         registry_version containerd_version calico_version calico_image_version \
-        device_plugin_version traefik_version helm_version registry_host registry_port <<< "$(python3 - <<PY
+        device_plugin_version traefik_version whoami_version helm_version registry_host registry_port <<< "$(python3 - <<PY
 import yaml,sys
 with open('$VARS_FILE') as f:
     data = yaml.safe_load(f)
 fields = ['offline_pkg_dir','offline_image_dir','kube_version',
           'kube_version_pkgs','registry_version','containerd_version','calico_version',
           'calico_image_version','device_plugin_version','traefik_version',
-          'helm_version','registry_host','registry_port']
+          'whoami_version','helm_version','registry_host','registry_port']
 print(' '.join(str(data.get(k,'')) for k in fields))
 PY
 )"
@@ -179,6 +179,10 @@ done
 # Traefik image
 docker pull traefik:v${traefik_version}
 docker save traefik:v${traefik_version} -o "traefik_v${traefik_version}.tar"
+
+# Traefik whoami image used by the optional test route
+docker pull traefik/whoami:${whoami_version}
+docker save traefik/whoami:${whoami_version} -o "whoami_${whoami_version}.tar"
 
 # Python image for the sample application
 docker pull python:3.12-alpine


### PR DESCRIPTION
## Summary
- add `whoami_version` variable
- fetch and save the `traefik/whoami` image
- load the whoami image into the local registry
- document that the helper script now downloads the image

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_687914e1687c832b9510de22dcfa8d56