### PR TITLE
Add kubelet restart if Calico pods fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Calico's manifest is applied in two phases. The playbook first installs its
 CustomResourceDefinitions and waits until the `FelixConfiguration` CRD becomes
 available before applying the rest of the resources. This avoids failures that
 can occur when the API server has not yet processed the CRDs during the initial
-apply.
+apply. After the manifest is applied, the playbook ensures all Calico pods
+reach the `Running` phase. If they remain pending, the kubelet service is
+restarted on every node and the readiness check is retried.
 
 
 The `traefik_gateway` role deploys a Traefik Gateway controller and related

--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -162,15 +162,35 @@
       environment: "{{ kubectl_env }}"
       become: true
 
-    - name: Wait for Calico pods to be ready
-      shell: |
-        kubectl get pods -n kube-system -l k8s-app=calico-node -o jsonpath='{.items[*].status.phase}'
-      register: calico_status
-      until: calico_status.stdout.split() | unique == ['Running']
-      retries: 20
-      delay: 15
-      environment: "{{ kubectl_env }}"
-      changed_when: false
-      become: true
+    - block:
+        - name: Wait for Calico pods to be ready
+          shell: |
+            kubectl get pods -n kube-system -l k8s-app=calico-node -o jsonpath='{.items[*].status.phase}'
+          register: calico_status
+          until: calico_status.stdout.split() | unique == ['Running']
+          retries: 20
+          delay: 15
+          environment: "{{ kubectl_env }}"
+          changed_when: false
+          become: true
+      rescue:
+        - name: Restart kubelet on all nodes
+          service:
+            name: kubelet
+            state: restarted
+          delegate_to: "{{ item }}"
+          loop: "{{ groups['all'] }}"
+          become: yes
+
+        - name: Wait for Calico pods after kubelet restart
+          shell: |
+            kubectl get pods -n kube-system -l k8s-app=calico-node -o jsonpath='{.items[*].status.phase}'
+          register: calico_status_after
+          until: calico_status_after.stdout.split() | unique == ['Running']
+          retries: 20
+          delay: 15
+          environment: "{{ kubectl_env }}"
+          changed_when: false
+          become: true
   when: is_first_master
 


### PR DESCRIPTION
## Summary
- ensure Calico pods reach `Running`
- if they don't, restart kubelet across all nodes and retry
- document Calico readiness and kubelet restart logic

## Testing
- `apt-get update -y`
- `apt-get install -y ansible`
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_687914fc3b48832ba5992b414bf25dfa