### PR TITLE
Auto-detect cunofs image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ its container images. The chart is extracted under
 Image references inside the chart are rewritten to use the
 `registry_host`/`registry_port` settings so the manifests can be applied
 fully offline.
+The script extracts the driver version from the Helm chart and pulls
+`cunofs/cunofs-csi:<version>` accordingly. The version is stored in the
+`cunofs_version` variable used by Ansible to load the tarball named
+`cunofs-csi_<version>.tar`.
 The `setup_registry` role loads these cunoFS image tarballs and pushes the
 images to the local registry so the driver can start without external access.
 The Helm version used for fetching can be customised via the

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -69,3 +69,4 @@ control_plane_endpoint: "{{ registry_master_ip }}:6443"
 # cunoFS license key
 cunofs_license_key: ""
 cunofs_namespace: "cunofs-system"
+cunofs_version: "1.0.4"

--- a/roles/cunofs-csi-driver/defaults/main.yml
+++ b/roles/cunofs-csi-driver/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 # Default variables for cunofs-csi-driver role
-# Set the image registry and tags to match your offline registry
-cunofs_controller_image: "registry.local/cunofs/csi-controller:latest"
-cunofs_node_image: "registry.local/cunofs/csi-node:latest"
+# Image tag is detected from the Helm chart when fetching assets
+# and stored in `cunofs_version`.
+cunofs_controller_image: "{{ registry_host }}:{{ registry_port }}/cunofs/cunofs-csi:{{ cunofs_version }}"
+cunofs_node_image: "{{ registry_host }}:{{ registry_port }}/cunofs/cunofs-csi:{{ cunofs_version }}"
 
 # Namespace to deploy the cunoFS CSI driver
 cunofs_namespace: "cunofs-system"

--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -91,8 +91,7 @@
     python_image: "python_3.12-alpine.tar"
     whoami_image: "whoami_{{ whoami_version }}.tar"
     cunofs_images:
-      - "csi-controller_latest.tar"
-      - "csi-node_latest.tar"
+      - "cunofs-csi_{{ cunofs_version }}.tar"
 
 # Download Kubernetes core image tarballs
 - name: Download Kubernetes core images


### PR DESCRIPTION
## Summary
- detect the cunoFS CSI image version from the Helm chart when fetching assets
- store the version in `cunofs_version` for Ansible
- pull and save `cunofs-csi` image using the detected tag
- update registry setup to load `cunofs-csi_<version>.tar`
- reference the new variable in defaults and documentation

## Testing
- `bash -n scripts/fetch_offline_assets.sh`

------
https://chatgpt.com/codex/tasks/task_e_687917ee2dec832ba6bbaaddf6037440