### PR TITLE
Update Traefik version

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -37,7 +37,7 @@ offline_image_dir: "/opt/offline/images" # Location of saved container images
 # Calico configuration
 calico_version: "v3.27.2"           # Manifest version
 calico_image_version: "v3.27.2"    # Container image tag
-traefik_version: "2.11.7"          # Traefik image tag
+traefik_version: "2.10.7"          # Traefik image tag
 whoami_version: "v1.10.1"          # traefik/whoami image tag used for tests
 helm_version: "v3.18.4"            # Helm CLI version used when fetching assets
 

--- a/roles/traefik_gateway/files/traefik-controller.yaml
+++ b/roles/traefik_gateway/files/traefik-controller.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: traefik-controller
       containers:
         - name: traefik
-          image: registrii.local:5000/traefik:v2.11.7
+          image: registrii.local:5000/traefik:v2.10.7
           args:
             - --providers.kubernetesgateway=true
             - --providers.kubernetesgateway

--- a/roles/traefik_gateway/vars/main.yml
+++ b/roles/traefik_gateway/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-traefik_version: "2.11.7"
+traefik_version: "2.10.7"


### PR DESCRIPTION
## Summary
- use Traefik v2.10.7 instead of v2.11.7
- keep manifests in sync with the new version

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_687d429db344832bb657c75e1f7c10bd