### PR TITLE
Fix Traefik helm templating

### DIFF
--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -287,6 +287,9 @@ image:
   registry: ${registry_host}:${registry_port}
   repository: traefik
   tag: v${traefik_version}
+updateStrategy:
+  rollingUpdate:
+    maxUnavailable: 1
 EOF
 
 tmp_chart=$(mktemp -d)


### PR DESCRIPTION
## Summary
- add missing updateStrategy to the generated Traefik `values.yaml`

## Testing
- `shellcheck scripts/fetch_offline_assets.sh`
- `helm template traefik $chart_path --namespace traefik --create-namespace -f /tmp/val.yaml`

------
https://chatgpt.com/codex/tasks/task_e_687d59455520832b9e4ad37a8b6d315a