### PR TITLE
Fix Traefik manifest for offline deployment

### DIFF
--- a/roles/traefik_gateway/README.md
+++ b/roles/traefik_gateway/README.md
@@ -1,8 +1,9 @@
 # traefik_gateway role
 
 This role deploys Traefik Gateway in an air‑gapped Kubernetes cluster using a Helm chart rendered to YAML.
-The `fetch_offline_assets.sh` helper downloads the chart and generates `traefik.yaml` with `helm template` so Helm is not required on the target hosts.
-The role applies the Gateway API CRDs and then the rendered manifest which includes RBAC rules, the controller and the default `GatewayClass` and `Gateway` objects.
+The `fetch_offline_assets.sh` helper downloads the chart and generates `traefik.yaml` with `helm template` so Helm is not required on the target hosts.  The template command now includes CRDs to avoid additional downloads when deploying.
+The role applies the Gateway API CRDs and then the rendered manifest which includes RBAC rules, the controller and the default `GatewayClass` and `Gateway` objects. The dashboard IngressRoute is disabled to keep the deployment minimal.
+`fetch_offline_assets.sh` also strips the `maxSurge` field from the DaemonSet update strategy because Kubernetes forbids setting `maxSurge` when `maxUnavailable` is non-zero.
 
 ## Files
 - `standard-install.yaml` – Gateway API CRDs

--- a/roles/traefik_gateway/files/traefik.yaml
+++ b/roles/traefik_gateway/files/traefik.yaml
@@ -97,9 +97,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: traefik
       app.kubernetes.io/instance: traefik-traefik
-  updateStrategy: 
+  updateStrategy:
     rollingUpdate:
-      maxSurge: 1
       maxUnavailable: 1
     type: RollingUpdate
   minReadySeconds: 0
@@ -215,25 +214,3 @@ metadata:
   name: traefik
 spec:
   controller: traefik.io/ingress-controller
----
-# Source: traefik/templates/dashboard-ingressroute.yaml
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: traefik-dashboard
-  namespace: traefik
-  annotations:
-  labels:
-    app.kubernetes.io/name: traefik
-    app.kubernetes.io/instance: traefik-traefik
-    helm.sh/chart: traefik-26.0.0
-    app.kubernetes.io/managed-by: Helm
-spec:
-  entryPoints:
-  - traefik
-  routes:
-  - match: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
-    kind: Rule
-    services:
-    - name: api@internal
-      kind: TraefikService

--- a/roles/traefik_gateway/files/values.yaml
+++ b/roles/traefik_gateway/files/values.yaml
@@ -17,3 +17,6 @@ image:
 updateStrategy:
   rollingUpdate:
     maxUnavailable: 1
+ingressRoute:
+  dashboard:
+    enabled: false

--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -300,8 +300,12 @@ chart_path="$tmp_chart/traefik"
 helm template traefik "$chart_path" \
   --namespace traefik \
   --create-namespace \
+  --include-crds \
   -f "$gateway_files_dir/values.yaml" \
   > "$gateway_files_dir/traefik.yaml"
+
+# Remove maxSurge which is invalid for DaemonSet updateStrategy
+sed -i '/maxSurge:/d' "$gateway_files_dir/traefik.yaml"
 rm -rf "$tmp_chart"
 # Cleanup temporary download directory
 rm -rf "$download_tmp"


### PR DESCRIPTION
## Summary
- include CRDs when templating Traefik and drop invalid maxSurge
- disable dashboard ingress route via values file
- strip maxSurge from existing manifest and remove IngressRoute
- document the changes in the role README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d5d2510ac832bb6e11ab251377afb