### PR TITLE
Update Traefik ports to 80/443

### DIFF
--- a/roles/traefik_gateway/files/traefik.yaml
+++ b/roles/traefik_gateway/files/traefik.yaml
@@ -204,16 +204,18 @@ spec:
           containerPort: 8080
           protocol: TCP
         - name: web
-          containerPort: 8000
+          containerPort: 80
           protocol: TCP
         - name: websecure
-          containerPort: 8443
+          containerPort: 443
           protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-            - ALL
+              - ALL
+            add:
+              - NET_BIND_SERVICE
           readOnlyRootFilesystem: true
         volumeMounts:
           - name: data
@@ -224,8 +226,8 @@ spec:
           - "--global.checkNewVersion"
           - "--entryPoints.metrics.address=:9100/tcp"
           - "--entryPoints.traefik.address=:8080/tcp"
-          - "--entryPoints.web.address=:8000/tcp"
-          - "--entryPoints.websecure.address=:8443/tcp"
+          - "--entryPoints.web.address=:80/tcp"
+          - "--entryPoints.websecure.address=:443/tcp"
           - "--api.dashboard=true"
           - "--ping=true"
           - "--metrics.prometheus=true"
@@ -284,9 +286,18 @@ metadata:
 spec:
   gatewayClassName: traefik
   listeners:
-    - name: web
-      port: 8000
+    - name: http
       protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      protocol: HTTPS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: All
 ---
 # Source: traefik/templates/gatewayclass.yaml
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
## Summary
- expose Traefik web/websecure entrypoints on ports 80 and 443
- add `NET_BIND_SERVICE` so Traefik can bind to privileged ports
- set Gateway listeners to 80 and 443
- run `ansible-playbook --syntax-check`

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_687d728d70bc832bbbf39544b895a8de