### PR TITLE
Fix invalid cunoFS CSI deployment templates

### DIFF
--- a/roles/cunofs-csi-driver/templates/csi-controller.yaml.j2
+++ b/roles/cunofs-csi-driver/templates/csi-controller.yaml.j2
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,14 +13,14 @@ spec:
     metadata:
       labels:
         app: cunofs-csi-controller
-      spec:
-        containers:
-          - name: csi-controller
-            image: {{ cunofs_controller_image }}
-            env:
-              - name: NODE_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: spec.nodeName
-            args:
-              - "--node=$(NODE_NAME)"
+    spec:
+      containers:
+        - name: csi-controller
+          image: {{ cunofs_controller_image }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          args:
+            - "--node=$(NODE_NAME)"

--- a/roles/cunofs-csi-driver/templates/csi-node.yaml.j2
+++ b/roles/cunofs-csi-driver/templates/csi-node.yaml.j2
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -11,14 +12,14 @@ spec:
     metadata:
       labels:
         app: cunofs-csi-node
-      spec:
-        containers:
-          - name: csi-node
-            image: {{ cunofs_node_image }}
-            env:
-              - name: NODE_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: spec.nodeName
-            args:
-              - "--node=$(NODE_NAME)"
+    spec:
+      containers:
+        - name: csi-node
+          image: {{ cunofs_node_image }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          args:
+            - "--node=$(NODE_NAME)"


### PR DESCRIPTION
## Summary
- correct indentation in `csi-controller.yaml.j2`
- correct indentation in `csi-node.yaml.j2`
- add document start marker to both templates

## Testing
- `yamllint roles/cunofs-csi-driver/templates/csi-controller.yaml.j2`
- `yamllint roles/cunofs-csi-driver/templates/csi-node.yaml.j2`
- `ansible-playbook site.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_687df31efdd0832ba7444a7251582440