### PR TITLE
Fix Traefik binding for offline cluster

### DIFF
--- a/roles/traefik_gateway/files/traefik.yaml
+++ b/roles/traefik_gateway/files/traefik.yaml
@@ -162,6 +162,8 @@ spec:
           capabilities:
             drop:
             - ALL
+            add:
+            - NET_BIND_SERVICE
           readOnlyRootFilesystem: true
         volumeMounts:
           - name: data

--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -311,6 +311,8 @@ awk 'FNR==1 && NR>1{print "---"} {print}' "$crds_dir"/*.yaml > "$gateway_files_d
 
 # Remove maxSurge which is invalid for DaemonSet updateStrategy
 sed -i '/maxSurge:/d' "$gateway_files_dir/traefik.yaml"
+# Grant capability to bind privileged ports
+sed -i '/drop:/a\            add:\n            - NET_BIND_SERVICE' "$gateway_files_dir/traefik.yaml"
 rm -rf "$tmp_chart" "$tmp_chart_crds"
 # Cleanup temporary download directory
 rm -rf "$download_tmp"


### PR DESCRIPTION
## Summary
- grant NET_BIND_SERVICE capability to Traefik
- patch fetch script to add capability when regenerating manifest

## Testing
- `python3 scripts/serve_assets.py --help`

------
https://chatgpt.com/codex/tasks/task_e_687e0d1fec08832b90493716f560af53