### PR TITLE
Fix Traefik Gateway entrypoints

### DIFF
--- a/roles/traefik_gateway/files/traefik-controller.yaml
+++ b/roles/traefik_gateway/files/traefik-controller.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: traefik-controller
       containers:
         - name: traefik
-          image: registrii.local:5000/traefik:v2.10.7
+          image: registrii.local:5000/traefik:v3.4.1
           args:
             - --providers.kubernetesgateway=true
             - --providers.kubernetesgateway

--- a/roles/traefik_gateway/files/traefik.yaml
+++ b/roles/traefik_gateway/files/traefik.yaml
@@ -119,7 +119,7 @@ spec:
       terminationGracePeriodSeconds: 60
       hostNetwork: true
       containers:
-      - image: registrii.local:5000/traefik:v2.10.7
+      - image: registrii.local:5000/traefik:v3.4.1
         imagePullPolicy: IfNotPresent
         name: traefik
         resources:
@@ -181,7 +181,8 @@ spec:
           - "--ping=true"
           - "--metrics.prometheus=true"
           - "--metrics.prometheus.entrypoint=metrics"
-          - "--providers.kubernetescrd"
+          - "--providers.kubernetesgateway=true"
+          - "--providers.kubernetesgateway"
           - "--entrypoints.websecure.http.tls=true"
           - "--log.level=debug"
         env:

--- a/roles/traefik_gateway/files/values.yaml
+++ b/roles/traefik_gateway/files/values.yaml
@@ -20,7 +20,7 @@ service:
 image:
   registry: registrii.local:5000
   repository: traefik
-  tag: v2.10.7
+  tag: v3.4.1
 updateStrategy:
   rollingUpdate:
     maxUnavailable: 1


### PR DESCRIPTION
## Summary
- set traefik image to v3.4.1
- enable the Kubernetes Gateway provider in the manifest
- update example controller manifest and values

## Testing
- `pip install ansible-lint`
- `ansible-lint site.yml` *(fails: 334 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e13492a04832b8cd1bb98046520bd