### PR TITLE
Update README and RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ kubectl get pods -n traefik-system
 
 A healthy daemonset and `Accepted=True` GatewayClass mean the controller is ready
 to program the Gateway and associated routes.
+Once reconciled, `kubectl describe gateway traefik-gateway -n default` lists the assigned `Address`.
+If the controller logs contain RBAC errors such as `configmaps is forbidden` or
+`endpointslices.discovery.k8s.io is forbidden`, edit the Traefik ClusterRole to
+allow listing these resources.
 
 A missing GatewayClass or incorrect `parentRefs` will prevent Traefik from using
 the route. Once the route is accepted, the sample page should load from any

--- a/roles/traefik_gateway/files/rbac.yaml
+++ b/roles/traefik_gateway/files/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
   name: traefik-controller
 rules:
   - apiGroups: ['']
-    resources: ['services', 'endpoints', 'secrets']
+    resources: ['services', 'endpoints', 'secrets', 'configmaps']
     verbs: ['get', 'list', 'watch']
   - apiGroups: ['discovery.k8s.io']
     resources: ['endpointslices']

--- a/roles/traefik_gateway/files/traefik.yaml
+++ b/roles/traefik_gateway/files/traefik.yaml
@@ -39,6 +39,15 @@ rules:
       - services
       - endpoints
       - secrets
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
     verbs:
       - get
       - list


### PR DESCRIPTION
## Summary
- explain RBAC errors when Traefik gateway waits for controller
- allow listing configmaps and endpointslices in Traefik roles

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_687e52fc1a8c832bb845989408498a80