### PR TITLE
Fix Traefik gateway HTTPS listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ The `traefik_gateway` role deploys a Traefik Gateway controller and related
 Gateway API resources using a manifest rendered from the official Helm chart.
 Traefik runs as a DaemonSet so every node exposes ports 80 and 443. The
 rendered manifest references container images in the local registry so the
-gateway can be installed entirely offline.
+gateway can be installed entirely offline. During deployment the role creates a
+self-signed certificate and stores it in a `traefik-cert` Secret so the HTTPS
+listener is enabled without external dependencies.
 
 The `sample_app` role provides a minimal Deployment, Service and HTTPRoute that
 use only local manifests and images. It allows quick end‑to‑end testing of the

--- a/roles/traefik_gateway/README.md
+++ b/roles/traefik_gateway/README.md
@@ -3,6 +3,7 @@
 This role deploys Traefik Gateway in an air‑gapped Kubernetes cluster using a Helm chart rendered to YAML.
 The `fetch_offline_assets.sh` helper downloads the Traefik chart and renders `traefik.yaml` with `helm template` so Helm is not required on the target hosts. It also pulls the companion `traefik-crds` chart and concatenates its CRD files into `traefik-crds.yaml`.
 The role applies the Gateway API CRDs and these Traefik CRDs before deploying the rendered manifest which includes RBAC rules, the controller and the default `GatewayClass` and `Gateway` objects. The dashboard IngressRoute is disabled to keep the deployment minimal.
+During the deployment the role generates a self-signed certificate and stores it in a `traefik-cert` Secret so the HTTPS listener of the Gateway is configured entirely offline.
 `fetch_offline_assets.sh` also strips the `maxSurge` field from the DaemonSet update strategy because Kubernetes forbids setting `maxSurge` when `maxUnavailable` is non-zero.
 
 ## Files

--- a/roles/traefik_gateway/files/traefik.yaml
+++ b/roles/traefik_gateway/files/traefik.yaml
@@ -294,6 +294,14 @@ spec:
     - name: web
       port: 8000
       protocol: HTTP
+    - name: websecure
+      port: 8443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - name: traefik-cert
+            kind: Secret
+            group: ""
 ---
 # Source: traefik/templates/gatewayclass.yaml
 apiVersion: gateway.networking.k8s.io/v1

--- a/roles/traefik_gateway/tasks/main.yml
+++ b/roles/traefik_gateway/tasks/main.yml
@@ -41,6 +41,18 @@
   environment: "{{ kubectl_env }}"
   become: true
 
+- name: Create self-signed certificate for Traefik
+  shell: |
+    if ! kubectl get secret traefik-cert -n traefik >/dev/null 2>&1; then
+      openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+        -keyout /tmp/traefik.key -out /tmp/traefik.crt \
+        -subj "/CN=traefik.local"
+      kubectl create secret tls traefik-cert \
+        --cert=/tmp/traefik.crt --key=/tmp/traefik.key -n traefik
+    fi
+  environment: "{{ kubectl_env }}"
+  become: true
+
 
 - name: Copy rendered Traefik manifest
   copy:


### PR DESCRIPTION
## Summary
- set up self-signed TLS secret before deploying Traefik
- enable `websecure` listener in rendered gateway manifest
- document TLS secret generation

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_687f5989defc832b8d2be1958bb219a4