### PR TITLE
Fix cunoFS driver license injection

### DIFF
--- a/roles/cunofs-csi-driver/README.md
+++ b/roles/cunofs-csi-driver/README.md
@@ -6,6 +6,9 @@ internet access is required once the assets have been fetched.
 The chart and container images are downloaded by
 `scripts/fetch_offline_assets.sh` and reference the private registry.
 
-Set `cunofs_license_key` to provide your license string. The driver will be
-installed into the namespace defined by `cunofs_namespace` (default
-`cunofs-system`). Image names can be adjusted in `defaults/main.yml`.
+Set `cunofs_license_key` to provide your license string. A Kubernetes Secret
+named `cunofs-license` is created and the `CUNOFS_LICENSE` environment
+variable for the controller and node pods references this secret so the driver
+starts correctly. The driver will be installed into the namespace defined by
+`cunofs_namespace` (default `cunofs-system`). Image names can be adjusted in
+`defaults/main.yml`.

--- a/roles/cunofs-csi-driver/templates/csi-controller.yaml.j2
+++ b/roles/cunofs-csi-driver/templates/csi-controller.yaml.j2
@@ -22,5 +22,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: CUNOFS_LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: cunofs-license
+                  key: license
           args:
             - "--node=$(NODE_NAME)"

--- a/roles/cunofs-csi-driver/templates/csi-node.yaml.j2
+++ b/roles/cunofs-csi-driver/templates/csi-node.yaml.j2
@@ -21,5 +21,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: CUNOFS_LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: cunofs-license
+                  key: license
           args:
             - "--node=$(NODE_NAME)"


### PR DESCRIPTION
## Summary
- inject license secret into cunoFS controller and node pods
- document environment variable handling in role README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f7800f514832baf4d59a9cdac15b2