### PR TITLE
Fix VARS_FILE references in asset fetch script

### DIFF
--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -51,7 +51,7 @@ print(' '.join(str(data.get(k,'')) for k in fields))
 PY
 )"
 
-kubernetes_packages=( $(python3 - <<'PY'
+kubernetes_packages=( $(python3 - <<PY
 import yaml
 from jinja2 import Template
 text=open('$VARS_FILE').read()
@@ -62,7 +62,7 @@ print(' '.join(data.get('kubernetes_packages', [])))
 PY
 ) )
 
-registry_packages=( $(python3 - <<'PY'
+registry_packages=( $(python3 - <<PY
 import yaml
 from jinja2 import Template
 text=open('$VARS_FILE').read()


### PR DESCRIPTION
## Summary
- ensure bash expands VARS_FILE when building Kubernetes and registry package lists

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687f92d80090832b9feefab04b9137d4