### PR TITLE
Update Calico images and registry variable

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -35,8 +35,9 @@ offline_pkg_dir: "/opt/offline/pkgs"   # Location where .deb files are stored
 offline_image_dir: "/opt/offline/images" # Location of saved container images
 
 # Calico configuration
-calico_version: "v3.27.2"           # Manifest version
-calico_image_version: "v3.27.2"    # Container image tag
+calico_version: "v3.30.2"           # Manifest version
+calico_image_version: "v3.30.2"    # Container image tag
+tigera_operator_version: "v1.38.3"  # Tigera operator image tag
 traefik_version: "3.4.1"          # Traefik image tag
 whoami_version: "v1.10.1"          # traefik/whoami image tag used for tests
 traefik_chart_version: "36.0.0"    # Helm chart version used for templating
@@ -46,6 +47,7 @@ helm_version: "v3.18.4"            # Helm CLI version used when fetching assets
 # Private registry settings
 registry_host: "registry.local"
 registry_port: 5000
+registry: "{{ registry_host }}:{{ registry_port }}"
 
 # Simple HTTP server settings used to distribute offline assets
 asset_server_port: 8081

--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -83,9 +83,20 @@
       - "coredns_v1.11.3.tar"
       - "pause_3.10.tar"
     calico_images:
-      - "cni_{{ calico_image_version }}.tar"
+      - "operator_{{ tigera_operator_version }}.tar"
       - "node_{{ calico_image_version }}.tar"
+      - "cni_{{ calico_image_version }}.tar"
+      - "apiserver_{{ calico_image_version }}.tar"
       - "kube-controllers_{{ calico_image_version }}.tar"
+      - "envoy-gateway_{{ calico_image_version }}.tar"
+      - "envoy-proxy_{{ calico_image_version }}.tar"
+      - "envoy-ratelimit_{{ calico_image_version }}.tar"
+      - "dikastes_{{ calico_image_version }}.tar"
+      - "pod2daemon-flexvol_{{ calico_image_version }}.tar"
+      - "key-cert-provisioner_{{ calico_image_version }}.tar"
+      - "goldmane_{{ calico_image_version }}.tar"
+      - "whisker_{{ calico_image_version }}.tar"
+      - "whisker-backend_{{ calico_image_version }}.tar"
     nvidia_plugin_image: "nvidia-device-plugin_{{ device_plugin_version }}.tar"
     traefik_image: "traefik_v{{ traefik_version }}.tar"
     python_image: "python_3.12-alpine.tar"
@@ -106,8 +117,8 @@
   shell: |
     img=$(docker load -i /tmp/{{ item }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
-    docker tag $img {{ registry_host }}:{{ registry_port }}/$name
-    docker push {{ registry_host }}:{{ registry_port }}/$name
+    docker tag $img {{ registry }}/$name
+    docker push {{ registry }}/$name
   args:
     executable: /bin/bash
   loop: "{{ kube_core_images }}"
@@ -128,8 +139,8 @@
   shell: |
     img=$(docker load -i /tmp/{{ item }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
-    docker tag $img {{ registry_host }}:{{ registry_port }}/$name
-    docker push {{ registry_host }}:{{ registry_port }}/$name
+    docker tag $img {{ registry }}/$name
+    docker push {{ registry }}/$name
   args:
     executable: /bin/bash
   loop: "{{ calico_images }}"
@@ -151,8 +162,8 @@
     # Preserve the repository path so the image is available as
     # <registry_host>:<registry_port>/nvidia/k8s-device-plugin:<tag>
     name=$(echo "$img" | cut -d/ -f2-)
-    docker tag $img {{ registry_host }}:{{ registry_port }}/$name
-    docker push {{ registry_host }}:{{ registry_port }}/$name
+    docker tag $img {{ registry }}/$name
+    docker push {{ registry }}/$name
   args:
     executable: /bin/bash
   become: yes
@@ -170,8 +181,8 @@
   shell: |
     img=$(docker load -i /tmp/{{ traefik_image }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
-    docker tag $img {{ registry_host }}:{{ registry_port }}/$name
-    docker push {{ registry_host }}:{{ registry_port }}/$name
+    docker tag $img {{ registry }}/$name
+    docker push {{ registry }}/$name
   args:
     executable: /bin/bash
   become: yes
@@ -189,8 +200,8 @@
   shell: |
     img=$(docker load -i /tmp/{{ python_image }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
-    docker tag $img {{ registry_host }}:{{ registry_port }}/$name
-    docker push {{ registry_host }}:{{ registry_port }}/$name
+    docker tag $img {{ registry }}/$name
+    docker push {{ registry }}/$name
   args:
     executable: /bin/bash
   become: yes
@@ -208,15 +219,15 @@
   shell: |
     img=$(docker load -i /tmp/{{ whoami_image }} | awk '/Loaded image:/ {print $3}')
     name=$(echo "$img" | awk -F/ '{print $NF}')
-    docker tag $img {{ registry_host }}:{{ registry_port }}/$name
-    docker push {{ registry_host }}:{{ registry_port }}/$name
+    docker tag $img {{ registry }}/$name
+    docker push {{ registry }}/$name
   args:
     executable: /bin/bash
   become: yes
 
 # Optional verification that the registry is serving
 - name: Verify local registry catalog
-  shell: curl -sf http://{{ registry_host }}:{{ registry_port }}/v2/_catalog
+  shell: curl -sf http://{{ registry }}/v2/_catalog
   register: registry_check
   changed_when: false
   become: yes

--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -35,7 +35,7 @@ fi
 
 read -r offline_pkg_dir offline_image_dir kube_version kube_version_pkgs \
         registry_version containerd_version calico_version calico_image_version \
-        device_plugin_version traefik_version whoami_version traefik_chart_version traefik_crds_chart_version helm_version registry_host registry_port nvidia_driver_runfile <<< "$(python3 - <<PY
+        tigera_operator_version device_plugin_version traefik_version whoami_version traefik_chart_version traefik_crds_chart_version helm_version registry_host registry_port nvidia_driver_runfile <<< "$(python3 - <<PY
 
 import yaml
 from jinja2 import Template
@@ -45,7 +45,7 @@ rendered=Template(text).render(**data)
 data=yaml.safe_load(rendered)
 fields=['offline_pkg_dir','offline_image_dir','kube_version','kube_version_pkgs',
         'registry_version','containerd_version','calico_version','calico_image_version',
-        'device_plugin_version','traefik_version','whoami_version','traefik_chart_version',
+        'tigera_operator_version','device_plugin_version','traefik_version','whoami_version','traefik_chart_version',
         'traefik_crds_chart_version','helm_version','registry_host','registry_port','nvidia_driver_runfile']
 print(' '.join(str(data.get(k,'')) for k in fields))
 PY
@@ -235,9 +235,20 @@ docker save python:3.12-alpine -o python_3.12-alpine.tar
 
 # Calico images
 calico_images=(
-  "docker.io/calico/cni:${calico_image_version}"
+  "quay.io/tigera/operator:${tigera_operator_version}"
   "docker.io/calico/node:${calico_image_version}"
+  "docker.io/calico/cni:${calico_image_version}"
+  "docker.io/calico/apiserver:${calico_image_version}"
   "docker.io/calico/kube-controllers:${calico_image_version}"
+  "docker.io/calico/envoy-gateway:${calico_image_version}"
+  "docker.io/calico/envoy-proxy:${calico_image_version}"
+  "docker.io/calico/envoy-ratelimit:${calico_image_version}"
+  "docker.io/calico/dikastes:${calico_image_version}"
+  "docker.io/calico/pod2daemon-flexvol:${calico_image_version}"
+  "docker.io/calico/key-cert-provisioner:${calico_image_version}"
+  "docker.io/calico/goldmane:${calico_image_version}"
+  "docker.io/calico/whisker:${calico_image_version}"
+  "docker.io/calico/whisker-backend:${calico_image_version}"
 )
 for img in "${calico_images[@]}"; do
   base="$(basename "$img")"


### PR DESCRIPTION
## Summary
- add `registry` and `tigera_operator_version` variables
- update Calico version to v3.30.2
- fetch additional Calico images including the Tigera operator
- push images using the new `registry` variable

## Testing
- `ansible-playbook --syntax-check site.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688230fd7a80832bb6c3bab0344a9a47