### PR TITLE
Update NFS plugin tarball name

### DIFF
--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -98,7 +98,7 @@
       - "whisker_{{ calico_image_version }}.tar"
       - "whisker-backend_{{ calico_image_version }}.tar"
     storage_images:
-      - "nfsplugin.tar"
+      - "nfsplugin_canary.tar"
       - "csi-provisioner_{{ csi_provisioner_version }}.tar"
       - "csi-resizer_{{ csi_resizer_version }}.tar"
       - "csi-snapshotter_{{ csi_snapshotter_version }}.tar"


### PR DESCRIPTION
## Summary
- use `nfsplugin_canary.tar` in setup_registry

## Testing
- `ansible-lint site.yml` *(fails: many violations)*

------
https://chatgpt.com/codex/tasks/task_e_688241c11514832b9e98500d1fd3f30b