### PR TITLE
Update pause image version

### DIFF
--- a/roles/install_k8s/templates/containerd_config.toml.j2
+++ b/roles/install_k8s/templates/containerd_config.toml.j2
@@ -64,7 +64,8 @@ version = 2
     max_container_log_line_size = 16384
     netns_mounts_under_state_dir = false
     restrict_oom_score_adj = false
-    sandbox_image = "{{ registry }}/pause:3.8"
+    # Use the same pause image version downloaded by fetch_offline_assets.sh
+    sandbox_image = "{{ registry }}/pause:3.10"
     selinux_category_range = 1024
     stats_collect_period = 10
     stream_idle_timeout = "4h0m0s"


### PR DESCRIPTION
## Summary
- configure containerd to use the same pause image version that the offline asset scripts download

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_6882443ce9ec832b9aca4c4a2872bb58