### PR TITLE
Fix Calico image paths in registry role

### DIFF
--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -146,7 +146,9 @@
 - name: Load and push Calico images
   shell: |
     img=$(docker load -i /tmp/{{ item }} | awk '/Loaded image:/ {print $3}')
-    name=$(echo "$img" | awk -F/ '{print $NF}')
+    # Preserve the repository path so the image is available as
+    # <registry_host>:<registry_port>/calico/<name>:<tag>
+    name=$(echo "$img" | cut -d/ -f2-)
     docker tag $img {{ registry }}/$name
     docker push {{ registry }}/$name
   args:


### PR DESCRIPTION
## Summary
- preserve Calico repository path when pushing images to local registry

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_688255b65688832b8d6d99c5c1505a30