### PR TITLE
Ensure Calico CRDs applied first

### DIFF
--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -133,18 +133,24 @@
   become: yes
 
 - block:
+    - name: Copy Calico CRD manifest
+      copy:
+        src: calicocrd.yaml
+        dest: /tmp/calicocrd.yaml
+        mode: '0644'
+      become: true
+
+    - name: Apply Calico CRD manifest
+      shell: kubectl apply -f /tmp/calicocrd.yaml
+      environment: "{{ kubectl_env }}"
+      become: true
+
     - name: Copy Calico manifest
       copy:
         src: calico.yaml
         dest: /tmp/calico.yaml
         mode: '0644'
       become: true
-
-    - name: Apply Calico CRDs (initial pass)
-      shell: kubectl apply -f /tmp/calico.yaml || true
-      environment: "{{ kubectl_env }}"
-      become: true
-      failed_when: false
 
     - name: Wait for FelixConfiguration CRD
       shell: kubectl get crd felixconfigurations.crd.projectcalico.org
@@ -162,9 +168,9 @@
       become: true
 
     - block:
-        - name: Wait for Calico pods to be ready
+        - name: Wait for Calico pods in calico-system
           shell: |
-            kubectl get pods -n kube-system -l k8s-app=calico-node -o jsonpath='{.items[*].status.phase}'
+            kubectl get pods -n calico-system -o jsonpath='{.items[*].status.phase}'
           register: calico_status
           until: calico_status.stdout.split() | unique == ['Running']
           retries: 20
@@ -173,17 +179,14 @@
           changed_when: false
           become: true
       rescue:
-        - name: Restart kubelet on all nodes
-          service:
-            name: kubelet
-            state: restarted
-          delegate_to: "{{ item }}"
-          loop: "{{ groups['all'] }}"
-          become: yes
+        - name: Reapply Calico manifest
+          shell: kubectl apply -f /tmp/calico.yaml
+          environment: "{{ kubectl_env }}"
+          become: true
 
-        - name: Wait for Calico pods after kubelet restart
+        - name: Wait for Calico pods after reapply
           shell: |
-            kubectl get pods -n kube-system -l k8s-app=calico-node -o jsonpath='{.items[*].status.phase}'
+            kubectl get pods -n calico-system -o jsonpath='{.items[*].status.phase}'
           register: calico_status_after
           until: calico_status_after.stdout.split() | unique == ['Running']
           retries: 20


### PR DESCRIPTION
## Summary
- deploy Calico CRDs from `calicocrd.yaml` before applying `calico.yaml`
- look for pods in `calico-system` namespace and reapply the manifest if none appear

## Testing
- `yamllint roles/kubeadm_master/tasks/main.yml`
- `ansible-playbook --syntax-check site.yml`


------
https://chatgpt.com/codex/tasks/task_e_6882560fe32c832bb9e1192e4fbe65b8