### PR TITLE
Switch Calico CRD step to kubectl create

### DIFF
--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -140,8 +140,8 @@
         mode: '0644'
       become: true
 
-    - name: Apply Calico CRD manifest
-      shell: kubectl apply -f /tmp/calicocrd.yaml
+    - name: Create Calico CRD manifest
+      shell: kubectl create -f /tmp/calicocrd.yaml
       environment: "{{ kubectl_env }}"
       become: true
 


### PR DESCRIPTION
## Summary
- use `kubectl create` instead of `kubectl apply` when installing Calico CRDs

## Testing
- `ansible-playbook --syntax-check site.yml`
- `ansible-lint` *(fails: 2253 failures)*

------
https://chatgpt.com/codex/tasks/task_e_688258c1c630832bb4e695cfd8866d30