### PR TITLE
Fix Calico image tagging

### DIFF
--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -146,10 +146,15 @@
 - name: Load and push Calico images
   shell: |
     img=$(docker load -i /tmp/{{ item }} | awk '/Loaded image:/ {print $3}')
-    # Preserve the repository path so the image is available as
-    # <registry_host>:<registry_port>/calico/<name>:<tag>
-    name=$(echo "$img" | cut -d/ -f2-)
-    docker tag $img {{ registry }}/$name
+    # Preserve repository path but strip any registry domain
+    name="$img"
+    if [[ "$name" == */* ]]; then
+      first="${name%%/*}"
+      if [[ "$first" == *.* || "$first" == *:* ]]; then
+        name="${name#*/}"
+      fi
+    fi
+    docker tag "$img" {{ registry }}/$name
     docker push {{ registry }}/$name
   args:
     executable: /bin/bash


### PR DESCRIPTION
## Summary
- strip registry domain when tagging Calico images

## Testing
- `ansible-lint -v site.yml` *(fails: many rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68825b45eac0832b8ac43019fd07df09