### PR TITLE
Skip failure if Calico CRDs already exist

### DIFF
--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -142,8 +142,10 @@
 
     - name: Create Calico CRD manifest
       shell: kubectl create -f /tmp/calicocrd.yaml
+      register: calico_crd_result
       environment: "{{ kubectl_env }}"
       become: true
+      failed_when: calico_crd_result.rc != 0 and 'AlreadyExists' not in calico_crd_result.stderr
 
     - name: Copy Calico manifest
       copy:


### PR DESCRIPTION
## Summary
- skip fatal error when Calico CRDs already exist

## Testing
- `ansible-playbook site.yml --syntax-check -i inventory`

------
https://chatgpt.com/codex/tasks/task_e_68825b787254832baa2dd6734ba9a981