### PR TITLE
Add typha image for offline Calico

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ cluster once the gateway is running.
 
 `scripts/fetch_offline_assets.sh` now also saves the `traefik/whoami` image
 used by the optional test route so the gateway can serve traffic without
-external access.
+external access. The script additionally pulls the `calico/typha` image
+so Calico components start successfully in fully offline environments.
 
 `scripts/fetch_offline_assets.sh` also retrieves the NVIDIA GPU driver runfile
 specified by `nvidia_driver_runfile` and the `nvidia_packages`. These files are

--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -85,6 +85,7 @@
     calico_images:
       - "operator_{{ tigera_operator_version }}.tar"
       - "node_{{ calico_image_version }}.tar"
+      - "typha_{{ calico_image_version }}.tar"
       - "cni_{{ calico_image_version }}.tar"
       - "apiserver_{{ calico_image_version }}.tar"
       - "kube-controllers_{{ calico_image_version }}.tar"

--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -249,6 +249,7 @@ docker save python:3.12-alpine -o python_3.12-alpine.tar
 calico_images=(
   "quay.io/tigera/operator:${tigera_operator_version}"
   "docker.io/calico/node:${calico_image_version}"
+  "docker.io/calico/typha:${calico_image_version}"
   "docker.io/calico/cni:${calico_image_version}"
   "docker.io/calico/apiserver:${calico_image_version}"
   "docker.io/calico/kube-controllers:${calico_image_version}"


### PR DESCRIPTION
## Summary
- fetch `calico/typha` when gathering offline assets
- push `typha` tarball to local registry
- document that the script pulls the typha image

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688264cf0e7c832ba47b574a3844d0c4