### PR TITLE
Create tigera namespace before Calico install

### DIFF
--- a/roles/kubeadm_master/tasks/main.yml
+++ b/roles/kubeadm_master/tasks/main.yml
@@ -164,6 +164,13 @@
       changed_when: false
       become: true
 
+    - name: Ensure tigera-operator namespace exists
+      shell: kubectl create namespace tigera-operator
+      register: tigera_ns_result
+      environment: "{{ kubectl_env }}"
+      become: true
+      failed_when: tigera_ns_result.rc != 0 and 'AlreadyExists' not in tigera_ns_result.stderr
+
     - name: Apply Calico manifest
       shell: kubectl apply -f /tmp/calico.yaml
       environment: "{{ kubectl_env }}"


### PR DESCRIPTION
## Summary
- ensure `tigera-operator` namespace exists before applying Calico manifest

## Testing
- `ansible-playbook --syntax-check site.yml`

------
https://chatgpt.com/codex/tasks/task_e_688264dc769c832b868db0030b0ce910