### PR TITLE
Add missing Calico CSI images

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ cluster once the gateway is running.
 
 `scripts/fetch_offline_assets.sh` now also saves the `traefik/whoami` image
 used by the optional test route so the gateway can serve traffic without
-external access. The script additionally pulls the `calico/typha` image
-so Calico components start successfully in fully offline environments.
+external access. The script additionally pulls the `calico/typha`,
+`calico/csi` and `calico/node-driver-registrar` images so Calico components
+start successfully in fully offline environments.
 
 `scripts/fetch_offline_assets.sh` also retrieves the NVIDIA GPU driver runfile
 specified by `nvidia_driver_runfile` and the `nvidia_packages`. These files are

--- a/roles/setup_registry/tasks/main.yml
+++ b/roles/setup_registry/tasks/main.yml
@@ -94,6 +94,8 @@
       - "envoy-ratelimit_{{ calico_image_version }}.tar"
       - "dikastes_{{ calico_image_version }}.tar"
       - "pod2daemon-flexvol_{{ calico_image_version }}.tar"
+      - "csi_{{ calico_image_version }}.tar"
+      - "node-driver-registrar_{{ calico_image_version }}.tar"
       - "key-cert-provisioner_{{ calico_image_version }}.tar"
       - "goldmane_{{ calico_image_version }}.tar"
       - "whisker_{{ calico_image_version }}.tar"

--- a/scripts/fetch_offline_assets.sh
+++ b/scripts/fetch_offline_assets.sh
@@ -258,6 +258,8 @@ calico_images=(
   "docker.io/calico/envoy-ratelimit:${calico_image_version}"
   "docker.io/calico/dikastes:${calico_image_version}"
   "docker.io/calico/pod2daemon-flexvol:${calico_image_version}"
+  "docker.io/calico/csi:${calico_image_version}"
+  "docker.io/calico/node-driver-registrar:${calico_image_version}"
   "docker.io/calico/key-cert-provisioner:${calico_image_version}"
   "docker.io/calico/goldmane:${calico_image_version}"
   "docker.io/calico/whisker:${calico_image_version}"


### PR DESCRIPTION
## Summary
- document new CSI images in README
- fetch Calico CSI images when preparing offline assets
- push Calico CSI images to the local registry

## Testing
- `shellcheck scripts/fetch_offline_assets.sh`
- `ansible-lint` *(fails: yaml[empty-lines], var-naming, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688265142fb8832bbecf8f3a82fcdc8d